### PR TITLE
CI: Drop CI on MacOS

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,10 +14,10 @@ jobs:
   build-unix:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true 
       matrix:
-        os: [ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-16.04, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
* Enable fail-fast: Error on any one of the builds will stop all the others.
* Run CI only on linux and windows and python 3.6 and 3.8
