### PR TITLE
Add Publish-to-Test-PyPI workflow

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,69 @@
+# This workflow automatically publish to both Test PyPI when a pull-request to master is both tagged and merged. 
+# See: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish Python Package to Test PyPI
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ closed ]
+    paths: [ 'dnplab/**.py' ]
+
+jobs:
+  build-n-publish:
+    if: github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: true 
+      matrix:
+        python-version: [ 3.6 ]
+    steps:
+    
+      - uses: actions/checkout@v2.3.3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2.1.4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 black pytest 
+          pip install -r requirements.txt
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test with pytest  # pytest is compatible with unittest
+        run: |
+          python -m pytest
+
+      - name: Check PEP-8 format for code consistency
+        run: |
+          black . --check
+
+      - name: Build a binary wheel and a source tarball
+        # Following https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives
+        run: |
+          python3 -m pip install --upgrade setuptools wheel
+          python3 setup.py sdist bdist_wheel
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/
+          verbose: true
+
+  #     - name: Publish distribution 📦 to PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.4.1
+  #       with:
+  #         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This workflow enables automatically publication to Test PyPI. We will test it out and later turn to PyPI. 

The publication is triggered if and only if all of the following events happen:
- [x] There is a pull request to `master`
- [x] The pull request contains changes of `*.py` files in the `dnplab/` directory and its subdirectory.
- [x] The pull request is labeled `release`
- [x] The pull request is merged to `master`
- [x] After merge, the repo passes all of the following check points:
    - Can be built in `ubuntu-18.04` with `python 3.6`
    - Pass `flake8 . `, no syntax Error.
    - Pass `pytest .`, all test cases pass.
    - Pass `black . --check`, no inconsistent coding style. 
