### PR TITLE
Integrate accepts lists for center and width, calculate_enhancement looks for 'integrate' proc_attr

### DIFF
--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -214,7 +214,7 @@ def integrate(
     +------------------+---------------+----------+-------------------------------+
     | integrate_center | float or list | 0        | center of integration window  |
     +------------------+---------------+----------+-------------------------------+
-    | integrate_width  | float or list | 100      | width of integration window   |
+    | integrate_width  | float or list | "full"   | width of integration window   |
     +------------------+---------------+----------+-------------------------------+
 
     Returns:

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -6,6 +6,7 @@ import dnplab.dnpNMR as nmr
 import dnplab as dnp
 import numpy as np
 import os
+import copy
 
 
 class dnpNMR_tester(unittest.TestCase):
@@ -177,6 +178,8 @@ class dnpNMR_tester(unittest.TestCase):
         nmr.fourier_transform(self.ws, zero_fill_factor=2)
         nmr.autophase(self.ws, method="arctan")
 
+        ws = copy.deepcopy(self.ws)
+
         nmr.calculate_enhancement(
             self.ws,
             off_spectrum=1,
@@ -187,9 +190,7 @@ class dnpNMR_tester(unittest.TestCase):
             dim="f2",
         )
 
-        self.assertAlmostEqual(
-            self.ws["enhancement"].values[0], 1.0252541520454477, places=6
-        )
+        self.assertAlmostEqual(self.ws["enhancement"].values[0], 1.0, places=6)
         self.assertAlmostEqual(
             self.ws["enhancement"].values[-1], -1.3615844024369856, places=6
         )
@@ -214,6 +215,14 @@ class dnpNMR_tester(unittest.TestCase):
         )
         self.assertAlmostEqual(
             self.ws_off["enhancement"].values[-1], 0.004154668257187268, places=6
+        )
+
+        dnp.dnpTools.integrate(ws, integrate_center=0, integrate_width="full")
+        nmr.calculate_enhancement(ws, off_spectrum=1)
+
+        self.assertAlmostEqual(ws["enhancement"].values[0], 1.0, places=6)
+        self.assertAlmostEqual(
+            ws["enhancement"].values[-1], -1.3615844024369856, places=6
         )
 
 

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -120,8 +120,8 @@ class dnpNMR_tester(unittest.TestCase):
         self.assertAlmostEqual(
             min(self.ws["proc"].values[:, 3].real), -65.59778997862813, places=4
         )
-        phs0 = self.ws["proc"].attrs["phase_0"]
-        phs1 = self.ws["proc"].attrs["phase_1"]
+        phs0 = self.ws["proc"].attrs["phase0"]
+        phs1 = self.ws["proc"].attrs["phase1"]
         self.assertEqual(len(phs1), len(self.ws["proc"].values))
         self.ws.copy("proc", "keep")
         self.ws.copy("temp", "proc")

--- a/unittests/test_dnpTools.py
+++ b/unittests/test_dnpTools.py
@@ -93,11 +93,35 @@ class dnpTools_tester(unittest.TestCase):
         nmr.fourier_transform(ws, zero_fill_factor=2)
         nmr.autophase(ws, method="arctan")
 
+        ws2 = copy.deepcopy(ws)
+        ws3 = copy.deepcopy(ws)
         dnp.dnpTools.integrate(ws, dim="f2", integrate_center=0, integrate_width=50)
         self.assertEqual((8,), np.shape(ws["proc"].values))
         self.assertAlmostEqual(max(ws["proc"].values.real), 6170.447249940133, places=4)
         self.assertAlmostEqual(
             min(ws["proc"].values.real), -7188.897892203664, places=4
+        )
+
+        dnp.dnpTools.integrate(
+            ws2, dim="f2", integrate_center=[-10, 0, 10], integrate_width=50
+        )
+        self.assertEqual((3, 8), np.shape(ws2["proc"].values))
+        self.assertAlmostEqual(
+            max(ws2["proc"].values.real[1]), 6170.447249940133, places=4
+        )
+        self.assertAlmostEqual(
+            min(ws2["proc"].values.real[1]), -7188.897892203664, places=4
+        )
+
+        dnp.dnpTools.integrate(
+            ws3, dim="f2", integrate_center=[-10, 0, 10], integrate_width=[10, 50, 10]
+        )
+        self.assertEqual((3, 8), np.shape(ws2["proc"].values))
+        self.assertAlmostEqual(
+            max(ws3["proc"].values.real[1]), 6170.447249940133, places=4
+        )
+        self.assertAlmostEqual(
+            min(ws3["proc"].values.real[1]), -7188.897892203664, places=4
         )
 
     def test_mr_properties(self):

--- a/unittests/test_import_wrapper.py
+++ b/unittests/test_import_wrapper.py
@@ -11,21 +11,20 @@ class load_wrapper_tester(unittest.TestCase):
             ".", "data", "vnmrj", "10mM_tempol_in_water_array.fid"
         )
 
-
         self.list_prospa_dir = [
-                './data/prospa/toluene_10mM_Tempone/1/data.1d',
-                './data/prospa/toluene_10mM_Tempone/2/data.1d',
-                './data/prospa/toluene_10mM_Tempone/3/data.1d',
-                './data/prospa/toluene_10mM_Tempone/4/data.1d',
-                './data/prospa/toluene_10mM_Tempone/5/data.1d',
-                './data/prospa/toluene_10mM_Tempone/6/data.1d',
-                './data/prospa/toluene_10mM_Tempone/7/data.1d',
-                './data/prospa/toluene_10mM_Tempone/8/data.1d',
-                './data/prospa/toluene_10mM_Tempone/9/data.1d',
-                './data/prospa/toluene_10mM_Tempone/10/data.1d',
-                ]
+            "./data/prospa/toluene_10mM_Tempone/1/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/2/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/3/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/4/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/5/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/6/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/7/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/8/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/9/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/10/data.1d",
+        ]
         self.list_index = range(10)
-        self.dim_name = 'test_dim'
+        self.dim_name = "test_dim"
 
     def test_topspin(self):
         data = load(os.path.join(self.topspin_dir, str(1)), data_type="topspin")
@@ -41,7 +40,12 @@ class load_wrapper_tester(unittest.TestCase):
         load(self.vnmrj_dir, data_type="vnmrj")
 
     def test_import_list(self):
-        load(self.list_prospa_dir, data_type = "prospa", dim = self.dim_name, coord = self.list_index)
+        load(
+            self.list_prospa_dir,
+            data_type="prospa",
+            dim=self.dim_name,
+            coord=self.list_index,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] closes issue #103 
- [x] closes issue #99
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] integrate now accepts lists for center and width, calculate_enhancement looks for 'integrate' proc_attr first, fixed bug in autophase where phase could not be int, added warning messages reminding users to reference slices using logical (i.e. 1 to len) rather than pythonic (i.e. 0 to len-1), added unittests
