### PR TITLE
integrate, calculate_enhancement, fit add new keys rather than replace proc

### DIFF
--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -48,7 +48,7 @@ def exponential_fit(
     stretched=False,
     dim="t1",
     indirect_dim=None,
-    ws_key="integrate",
+    ws_key="integrals",
 ):
     """Fits various forms of exponential functions
 
@@ -77,7 +77,7 @@ def exponential_fit(
     +---------------+------+-------------+-----------------------------------------------------------------------------------+
     | indirect_dim  | str  | None        | indirect dimension                                                                |
     +---------------+------+-------------+-----------------------------------------------------------------------------------+
-    | ws_key        | str  | "integrate" | if False "p" is set to 1, if True "p" is a fit parameter                          |
+    | ws_key        | str  | "integrals" | if False "p" is set to 1, if True "p" is a fit parameter                          |
     +---------------+------+-------------+-----------------------------------------------------------------------------------+
 
 

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -46,7 +46,7 @@ def exponential_fit(
     all_data,
     type="mono",
     stretched=False,
-    dim="f2",
+    dim="t1",
     indirect_dim=None,
     ws_key="integrate",
 ):
@@ -88,23 +88,23 @@ def exponential_fit(
 
     data, isDict = return_data(all_data)
 
-    if not indirect_dim:
-        if len(data.dims) == 2:
-            ind_dim = list(set(data.dims) - set([dim]))[0]
-        elif len(data.dims) == 1:
-            ind_dim = data.dims[0]
-        else:
-            raise ValueError(
-                "you must specify the indirect dimension, use argument indirect_dim= "
-            )
-    else:
-        ind_dim = indirect_dim
-
     if ws_key in all_data.keys():
-        x_axis = all_data[ws_key].coords
+        x_axis = all_data[ws_key].coords[dim]
         new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
         input_data = _np.real(all_data[ws_key].values)
+        ind_dim = dim
     else:
+        if not indirect_dim:
+            if len(data.dims) == 2:
+                ind_dim = list(set(data.dims) - set([dim]))[0]
+            elif len(data.dims) == 1:
+                ind_dim = data.dims[0]
+            else:
+                raise ValueError(
+                    "you must specify the indirect dimension, use argument indirect_dim= "
+                )
+        else:
+            ind_dim = indirect_dim
         x_axis = data.coords[ind_dim]
         new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
         input_data = _np.real(data.values)

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -224,12 +224,12 @@ def enhancement_fit(dataDict):
 
     data, isDict = return_data(all_data)
 
-    if "enhancement" not in all_data.keys():
+    if "enhancements" not in all_data.keys():
         raise TypeError("please use dnpNMR.calculate_enhancement() first")
 
-    power_axes = all_data["enhancement"].coords["power"]
+    power_axes = all_data["enhancements"].coords["power"]
 
-    input_data = _np.real(all_data["enhancement"].values)
+    input_data = _np.real(all_data["enhancements"].values)
 
     x0 = [input_data[-1], 0.1]
 

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -88,23 +88,23 @@ def exponential_fit(
 
     data, isDict = return_data(all_data)
 
+    if not indirect_dim:
+        if len(data.dims) == 2:
+            ind_dim = list(set(data.dims) - set([dim]))[0]
+        elif len(data.dims) == 1:
+            ind_dim = data.dims[0]
+        else:
+            raise ValueError(
+                "you must specify the indirect dimension, use argument indirect_dim= "
+            )
+    else:
+        ind_dim = indirect_dim
+
     if ws_key in all_data.keys():
         x_axis = all_data[ws_key].coords
         new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
         input_data = _np.real(all_data[ws_key].values)
     else:
-        if not indirect_dim:
-            if len(data.dims) == 2:
-                ind_dim = list(set(data.dims) - set([dim]))[0]
-            elif len(data.dims) == 1:
-                ind_dim = data.dims[0]
-            else:
-                raise ValueError(
-                    "you must specify the indirect dimension, use argument indirect_dim= "
-                )
-        else:
-            ind_dim = indirect_dim
-
         x_axis = data.coords[ind_dim]
         new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
         input_data = _np.real(data.values)

--- a/dnplab/dnpIO/bes3t.py
+++ b/dnplab/dnpIO/bes3t.py
@@ -208,6 +208,10 @@ def load_dta(path_dta, path_ygf, params):
     ]:
         dims = ["t2"]
     elif params["x_unit"] in ["G", "mT", "T", "Field", "field"]:
+        if params["x_unit"] == "G":
+            abscissa = [x / 10 for x in abscissa]
+        elif params["x_unit"] == "T":
+            abscissa = [x * 1000 for x in abscissa]
         dims = ["B0"]
     else:
         dims = ["t2"]

--- a/dnplab/dnpIO/winepr.py
+++ b/dnplab/dnpIO/winepr.py
@@ -170,6 +170,10 @@ def load_spc(path, params):
     ]:
         dims = ["t2"]
     elif params["x_unit"] in ["G", "mT", "T", "Field", "field"]:
+        if params["x_unit"] == "G":
+            abscissa = [x / 10 for x in abscissa]
+        elif params["x_unit"] == "T":
+            abscissa = [x * 1000 for x in abscissa]
         dims = ["B0"]
     else:
         dims = ["t2"]

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -299,7 +299,7 @@ def calculate_enhancement(
     method="integrate",
     dim="f2",
     indirect_dim=None,
-    ws_key="integrate",
+    ws_key="integrals",
 ):
     """Calculate enhancement from DNP data
 
@@ -323,10 +323,10 @@ def calculate_enhancement(
     +------------------+----------------------------+-------------+----------------------------------------------------------------------+
     | indirect_dim     | str                        | None        | indirect dimension                                                   |
     +------------------+----------------------------+-------------+----------------------------------------------------------------------+
-    | ws_key           | str                        | "integrate" | object to use as values for calculating enhancement                  |
+    | ws_key           | str                        | "integrals" | object to use as values for calculating enhancement                  |
     +------------------+----------------------------+-------------+----------------------------------------------------------------------+
     Returns:
-        dnpdata: data object with "enhancement" key added
+        dnpdata: data object with "enhancements" key added
 
     """
     if off_spectrum == 0:
@@ -490,7 +490,7 @@ def calculate_enhancement(
                     integrate_center=integrate_center,
                     integrate_width=integrate_width,
                 )
-                on_data = enh_data["integrate"].values
+                on_data = enh_data["integrals"].values
 
             elif method == "amplitude":
                 on_data = []
@@ -517,7 +517,7 @@ def calculate_enhancement(
         enhancement_data = dnpdata(enh, [enh_coords_on], [ind_dim])
 
     if isDict:
-        all_data["enhancement"] = enhancement_data
+        all_data["enhancements"] = enhancement_data
         return all_data
     else:
         return enhancement_data

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -299,6 +299,7 @@ def calculate_enhancement(
     method="integrate",
     dim="f2",
     indirect_dim=None,
+    ws_key="integrate",
 ):
     """Calculate enhancement from DNP data
 
@@ -322,7 +323,8 @@ def calculate_enhancement(
     +------------------+----------------------------+-------------+----------------------------------------------------------------------+
     | indirect_dim     | str                        | None        | indirect dimension                                                   |
     +------------------+----------------------------+-------------+----------------------------------------------------------------------+
-
+    | ws_key           | str                        | "integrate" | object to use as values for calculating enhancement                  |
+    +------------------+----------------------------+-------------+----------------------------------------------------------------------+
     Returns:
         dnpdata: data object with "enhancement" key added
 
@@ -334,9 +336,13 @@ def calculate_enhancement(
 
     orig_data, isDict = return_data(all_data)
 
-    if any(x[0] == "integrate" for x in all_data["proc"].proc_attrs):
-        enh = _np.real(orig_data.values / orig_data.values[off_spectrum - 1])
-        enhancement_data = dnpdata(enh, [orig_data.coords], [orig_data.dims])
+    if ws_key in all_data.keys():
+        enh = _np.real(
+            all_data[ws_key].values / all_data[ws_key].values[off_spectrum - 1]
+        )
+        enhancement_data = dnpdata(
+            enh, [all_data[ws_key].coords], [all_data[ws_key].dims]
+        )
 
     else:
 
@@ -484,8 +490,7 @@ def calculate_enhancement(
                     integrate_center=integrate_center,
                     integrate_width=integrate_width,
                 )
-                data, _isDict = return_data(enh_data)
-                on_data = data.values
+                on_data = enh_data["integrate"].values
 
             elif method == "amplitude":
                 on_data = []

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -226,7 +226,7 @@ def integrate(
 
     data_new = None
     if type == "double":
-        data.attrs["first_integral"] = scipy.integrate.cumtrapz(
+        first_int = scipy.integrate.cumtrapz(
             data.values, x=data.coords[dim], axis=index, initial=0
         )
         data.values = first_int
@@ -284,26 +284,23 @@ def integrate(
             data_integrals.append(np.trapz(x.values, x=x.coords[dim], axis=index))
 
         data.values = np.array(data_integrals)
+        int_coords = [integrate_center, data.coords[ind_dim]]
+        indirect_dim = ["center", ind_dim]
 
     else:
         data.values = np.trapz(data.values, x=data.coords[dim], axis=index)
+        int_coords = [data.coords[ind_dim]]
+        indirect_dim = [ind_dim]
 
-    data.coords.pop(dim)
-
-    proc_parameters = {
-        "dim": dim,
-        "integrate_center": integrate_center,
-        "integrate_width": integrate_width,
-    }
-
-    proc_attr_name = "integrate"
-    data.add_proc_attrs(proc_attr_name, proc_parameters)
+    integrate_data = dnpdata(data.values, int_coords, indirect_dim)
+    if type == "double":
+        integrate_data.attrs["first_integral"] = first_int
 
     if isDict:
-        all_data[all_data.processing_buffer] = data
+        all_data["integrate"] = integrate_data
         return all_data
     else:
-        return data
+        return integrate_data
 
 
 def mr_properties(nucleus, *args):

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -226,8 +226,10 @@ def integrate(
 
     if len(data.dims) == 2:
         ind_dim = list(set(data.dims) - set([dim]))[0]
+        indirect_coords = data.coords[ind_dim]
     elif len(data.dims) == 1:
-        ind_dim = data.dims[0]
+        ind_dim = "index"
+        indirect_coords = [0]
 
     data_new = None
     if type == "double":
@@ -289,12 +291,12 @@ def integrate(
             data_integrals.append(np.trapz(x.values, x=x.coords[dim], axis=index))
 
         data.values = np.array(data_integrals)
-        int_coords = [integrate_center, data.coords[ind_dim]]
+        int_coords = [integrate_center, indirect_coords]
         indirect_dim = ["center", ind_dim]
 
     else:
         data.values = np.trapz(data.values, x=data.coords[dim], axis=index)
-        int_coords = [data.coords[ind_dim]]
+        int_coords = [indirect_coords]
         indirect_dim = [ind_dim]
 
     integrate_data = dnpdata(data.values, int_coords, indirect_dim)

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -214,7 +214,7 @@ def integrate(
     +------------------+---------------+----------+-------------------------------+
     | integrate_center | float or list | 0        | center of integration window  |
     +------------------+---------------+----------+-------------------------------+
-    | integrate_width  | float or list | 100      | width of integration window   |
+    | integrate_width  | float or list | "full"   | width of integration window   |
     +------------------+---------------+----------+-------------------------------+
 
     Returns:

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -304,7 +304,7 @@ def integrate(
         integrate_data.attrs["first_integral"] = first_int
 
     if isDict:
-        all_data["integrate"] = integrate_data
+        all_data["integrals"] = integrate_data
         return all_data
     else:
         return integrate_data

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -224,6 +224,11 @@ def integrate(
     data, isDict = return_data(all_data)
     index = data.index(dim)
 
+    if len(data.dims) == 2:
+        ind_dim = list(set(data.dims) - set([dim]))[0]
+    elif len(data.dims) == 1:
+        ind_dim = data.dims[0]
+
     data_new = None
     if type == "double":
         first_int = scipy.integrate.cumtrapz(
@@ -543,7 +548,7 @@ def signal_to_noise(
     +------------------+-------+-----------+------------------------------+
 
     Returns:
-        dnpdata: data object with attr "signal_to_noise" added
+        dnpdata: data object with attr "s_n" added
     """
 
     data, isDict = return_data(all_data)
@@ -604,7 +609,7 @@ def signal_to_noise(
     else:
         raise TypeError("only 1D or 2D data currently supported")
 
-    data.attrs["signal_to_noise"] = s_n
+    data.attrs["s_n"] = s_n
 
     if isDict:
         all_data[all_data.processing_buffer] = data

--- a/dnplab/hydrationGUI.py
+++ b/dnplab/hydrationGUI.py
@@ -35,9 +35,6 @@ from matplotlib.figure import Figure
 import numpy as np
 from scipy.io import loadmat, savemat
 import copy
-import re
-import datetime
-import time
 
 import dnplab
 

--- a/dnplab/hydrationGUI.py
+++ b/dnplab/hydrationGUI.py
@@ -736,13 +736,13 @@ class hydrationGUI(QMainWindow):
                 integrate_center=k,
                 integrate_width=width,
             )
-            if len(optcenter_workspace["integrate"].values) > 1:
+            if len(optcenter_workspace["integrals"].values) > 1:
                 intgrl_array.append(
-                    sum(abs(optcenter_workspace["integrate"].real.values))
+                    sum(abs(optcenter_workspace["integrals"].real.values))
                 )
             else:
                 intgrl_array.append(
-                    abs(optcenter_workspace["integrate"].real.values[-1])
+                    abs(optcenter_workspace["integrals"].real.values[-1])
                 )
         cent = np.argmax(intgrl_array)
         self.gui_dict["processing_spec"]["integration_center"] = indx[cent]
@@ -782,7 +782,7 @@ class hydrationGUI(QMainWindow):
                 )
                 imag_sum.append(
                     np.sum(
-                        abs(self.processing_workspace["integrate"].imag.values * -1j)
+                        abs(self.processing_workspace["integrals"].imag.values * -1j)
                     )
                 )
 
@@ -1414,14 +1414,14 @@ class hydrationGUI(QMainWindow):
                 == self.gui_dict["folder_structure"]["p0"]
             ):
                 self.gui_dict["dnpLab_data"]["p0"] = nextproc_workspace[
-                    "integrate"
+                    "integrals"
                 ].real.values[0]
             elif (
                 self.gui_dict["rawdata_function"]["folder"]
                 in self.gui_dict["folder_structure"]["enh"]
             ):
                 Ep = (
-                    nextproc_workspace["integrate"].real.values[0]
+                    nextproc_workspace["integrals"].real.values[0]
                     / self.gui_dict["dnpLab_data"]["p0"]
                 )
                 self.Ep.append(np.real(Ep))
@@ -1498,7 +1498,7 @@ class hydrationGUI(QMainWindow):
                             "proc"
                         ].coords["t1"]
                         self.gui_dict["t1_fit"]["t1Amps"] = nextproc_workspace[
-                            "integrate"
+                            "integrals"
                         ].real.values
 
                         self.gui_dict["t1_fit"]["xaxis"] = nextproc_workspace[
@@ -1953,12 +1953,12 @@ class hydrationGUI(QMainWindow):
             integrate_width=self.gui_dict["processing_spec"]["integration_width"],
         )
 
-        if len(adjslider_workspace["integrate"].values) == 1:
+        if len(adjslider_workspace["integrals"].values) == 1:
             pass
         else:
             self.gui_dict["t1_fit"]["tau"] = adjslider_workspace["proc"].coords["t1"]
             self.gui_dict["t1_fit"]["t1Amps"] = adjslider_workspace[
-                "integrate"
+                "integrals"
             ].real.values
 
             try:
@@ -1994,11 +1994,11 @@ class hydrationGUI(QMainWindow):
                     "t1"
                 ]
                 self.gui_dict["t1_fit"]["t1Amps"] = adjslider_workspace[
-                    "integrate"
+                    "integrals"
                 ].real.values
 
                 self.gui_dict["t1_fit"]["t1Amps_imag"] = adjslider_workspace[
-                    "integrate"
+                    "integrals"
                 ].imag.values
 
                 self.gui_dict["t1_fit"]["xaxis"] = adjslider_workspace["fit"].coords[

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -190,9 +190,9 @@ class dnpNMR_tester(unittest.TestCase):
             dim="f2",
         )
 
-        self.assertAlmostEqual(self.ws["enhancement"].values[0], 1.0, places=6)
+        self.assertAlmostEqual(self.ws["enhancements"].values[0], 1.0, places=6)
         self.assertAlmostEqual(
-            self.ws["enhancement"].values[-1], -1.3615844024369856, places=6
+            self.ws["enhancements"].values[-1], -1.3615844024369856, places=6
         )
 
         nmr.remove_offset(self.ws_off)
@@ -211,18 +211,18 @@ class dnpNMR_tester(unittest.TestCase):
         )
 
         self.assertAlmostEqual(
-            self.ws_off["enhancement"].values[0], -0.005967949713665632, places=6
+            self.ws_off["enhancements"].values[0], -0.005967949713665632, places=6
         )
         self.assertAlmostEqual(
-            self.ws_off["enhancement"].values[-1], 0.004154668257187268, places=6
+            self.ws_off["enhancements"].values[-1], 0.004154668257187268, places=6
         )
 
         dnp.dnpTools.integrate(ws, integrate_center=0, integrate_width="full")
         nmr.calculate_enhancement(ws, off_spectrum=1)
 
-        self.assertAlmostEqual(ws["enhancement"].values[0], 1.0, places=6)
+        self.assertAlmostEqual(ws["enhancements"].values[0], 1.0, places=6)
         self.assertAlmostEqual(
-            ws["enhancement"].values[-1], -1.3615844024369856, places=6
+            ws["enhancements"].values[-1], -1.3615844024369856, places=6
         )
 
 

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -6,6 +6,7 @@ import dnplab.dnpNMR as nmr
 import dnplab as dnp
 import numpy as np
 import os
+import copy
 
 
 class dnpNMR_tester(unittest.TestCase):
@@ -177,6 +178,8 @@ class dnpNMR_tester(unittest.TestCase):
         nmr.fourier_transform(self.ws, zero_fill_factor=2)
         nmr.autophase(self.ws, method="arctan")
 
+        ws = copy.deepcopy(self.ws)
+
         nmr.calculate_enhancement(
             self.ws,
             off_spectrum=1,
@@ -187,9 +190,7 @@ class dnpNMR_tester(unittest.TestCase):
             dim="f2",
         )
 
-        self.assertAlmostEqual(
-            self.ws["enhancement"].values[0], 1.0252541520454477, places=6
-        )
+        self.assertAlmostEqual(self.ws["enhancement"].values[0], 1.0, places=6)
         self.assertAlmostEqual(
             self.ws["enhancement"].values[-1], -1.3615844024369856, places=6
         )
@@ -214,6 +215,14 @@ class dnpNMR_tester(unittest.TestCase):
         )
         self.assertAlmostEqual(
             self.ws_off["enhancement"].values[-1], 0.004154668257187268, places=6
+        )
+
+        dnp.dnpTools.integrate(ws, integrate_center=0, integrate_width="full")
+        nmr.calculate_enhancement(ws, off_spectrum=1)
+
+        self.assertAlmostEqual(ws["enhancement"].values[0], 1.0, places=6)
+        self.assertAlmostEqual(
+            ws["enhancement"].values[-1], -1.3615844024369856, places=6
         )
 
 

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -120,8 +120,8 @@ class dnpNMR_tester(unittest.TestCase):
         self.assertAlmostEqual(
             min(self.ws["proc"].values[:, 3].real), -65.59778997862813, places=4
         )
-        phs0 = self.ws["proc"].attrs["phase_0"]
-        phs1 = self.ws["proc"].attrs["phase_1"]
+        phs0 = self.ws["proc"].attrs["phase0"]
+        phs1 = self.ws["proc"].attrs["phase1"]
         self.assertEqual(len(phs1), len(self.ws["proc"].values))
         self.ws.copy("proc", "keep")
         self.ws.copy("temp", "proc")

--- a/unittests/test_dnpTools.py
+++ b/unittests/test_dnpTools.py
@@ -93,11 +93,35 @@ class dnpTools_tester(unittest.TestCase):
         nmr.fourier_transform(ws, zero_fill_factor=2)
         nmr.autophase(ws, method="arctan")
 
+        ws2 = copy.deepcopy(ws)
+        ws3 = copy.deepcopy(ws)
         dnp.dnpTools.integrate(ws, dim="f2", integrate_center=0, integrate_width=50)
         self.assertEqual((8,), np.shape(ws["proc"].values))
         self.assertAlmostEqual(max(ws["proc"].values.real), 6170.447249940133, places=4)
         self.assertAlmostEqual(
             min(ws["proc"].values.real), -7188.897892203664, places=4
+        )
+
+        dnp.dnpTools.integrate(
+            ws2, dim="f2", integrate_center=[-10, 0, 10], integrate_width=50
+        )
+        self.assertEqual((3, 8), np.shape(ws2["proc"].values))
+        self.assertAlmostEqual(
+            max(ws2["proc"].values.real[1]), 6170.447249940133, places=4
+        )
+        self.assertAlmostEqual(
+            min(ws2["proc"].values.real[1]), -7188.897892203664, places=4
+        )
+
+        dnp.dnpTools.integrate(
+            ws3, dim="f2", integrate_center=[-10, 0, 10], integrate_width=[10, 50, 10]
+        )
+        self.assertEqual((3, 8), np.shape(ws2["proc"].values))
+        self.assertAlmostEqual(
+            max(ws3["proc"].values.real[1]), 6170.447249940133, places=4
+        )
+        self.assertAlmostEqual(
+            min(ws3["proc"].values.real[1]), -7188.897892203664, places=4
         )
 
     def test_mr_properties(self):

--- a/unittests/test_dnpTools.py
+++ b/unittests/test_dnpTools.py
@@ -94,34 +94,34 @@ class dnpTools_tester(unittest.TestCase):
         ws2 = copy.deepcopy(ws)
         ws3 = copy.deepcopy(ws)
         dnp.dnpTools.integrate(ws, dim="f2", integrate_center=0, integrate_width=50)
-        self.assertEqual((8,), np.shape(ws["integrate"].values))
+        self.assertEqual((8,), np.shape(ws["integrals"].values))
         self.assertAlmostEqual(
-            max(ws["integrate"].values.real), 6170.447249940133, places=4
+            max(ws["integrals"].values.real), 6170.447249940133, places=4
         )
         self.assertAlmostEqual(
-            min(ws["integrate"].values.real), -7188.897892203664, places=4
+            min(ws["integrals"].values.real), -7188.897892203664, places=4
         )
 
         dnp.dnpTools.integrate(
             ws2, dim="f2", integrate_center=[-10, 0, 10], integrate_width=50
         )
-        self.assertEqual((3, 8), np.shape(ws2["integrate"].values))
+        self.assertEqual((3, 8), np.shape(ws2["integrals"].values))
         self.assertAlmostEqual(
-            max(ws2["integrate"].values.real[1]), 6170.447249940133, places=4
+            max(ws2["integrals"].values.real[1]), 6170.447249940133, places=4
         )
         self.assertAlmostEqual(
-            min(ws2["integrate"].values.real[1]), -7188.897892203664, places=4
+            min(ws2["integrals"].values.real[1]), -7188.897892203664, places=4
         )
 
         dnp.dnpTools.integrate(
             ws3, dim="f2", integrate_center=[-10, 0, 10], integrate_width=[10, 50, 10]
         )
-        self.assertEqual((3, 8), np.shape(ws2["integrate"].values))
+        self.assertEqual((3, 8), np.shape(ws2["integrals"].values))
         self.assertAlmostEqual(
-            max(ws3["integrate"].values.real[1]), 6170.447249940133, places=4
+            max(ws3["integrals"].values.real[1]), 6170.447249940133, places=4
         )
         self.assertAlmostEqual(
-            min(ws3["integrate"].values.real[1]), -7188.897892203664, places=4
+            min(ws3["integrals"].values.real[1]), -7188.897892203664, places=4
         )
 
     def test_mr_properties(self):

--- a/unittests/test_dnpTools.py
+++ b/unittests/test_dnpTools.py
@@ -40,10 +40,8 @@ class dnpTools_tester(unittest.TestCase):
             noise_width="default",
         )
 
-        self.assertEqual(len(ws["proc"].attrs["signal_to_noise"]), 8)
-        self.assertAlmostEqual(
-            ws["proc"].attrs["signal_to_noise"][4], 10.91728842, places=6
-        )
+        self.assertEqual(len(ws["proc"].attrs["s_n"]), 8)
+        self.assertAlmostEqual(ws["proc"].attrs["s_n"][4], 10.91728842, places=6)
 
         nmr.remove_offset(self.ws_off)
         nmr.window(self.ws_off, linewidth=15)
@@ -59,7 +57,7 @@ class dnpTools_tester(unittest.TestCase):
         )
 
         self.assertAlmostEqual(
-            self.ws_off["proc"].attrs["signal_to_noise"], 3.3986939859030096, places=6
+            self.ws_off["proc"].attrs["s_n"], 3.3986939859030096, places=6
         )
 
     def test_baseline(self):
@@ -96,32 +94,34 @@ class dnpTools_tester(unittest.TestCase):
         ws2 = copy.deepcopy(ws)
         ws3 = copy.deepcopy(ws)
         dnp.dnpTools.integrate(ws, dim="f2", integrate_center=0, integrate_width=50)
-        self.assertEqual((8,), np.shape(ws["proc"].values))
-        self.assertAlmostEqual(max(ws["proc"].values.real), 6170.447249940133, places=4)
+        self.assertEqual((8,), np.shape(ws["integrate"].values))
         self.assertAlmostEqual(
-            min(ws["proc"].values.real), -7188.897892203664, places=4
+            max(ws["integrate"].values.real), 6170.447249940133, places=4
+        )
+        self.assertAlmostEqual(
+            min(ws["integrate"].values.real), -7188.897892203664, places=4
         )
 
         dnp.dnpTools.integrate(
             ws2, dim="f2", integrate_center=[-10, 0, 10], integrate_width=50
         )
-        self.assertEqual((3, 8), np.shape(ws2["proc"].values))
+        self.assertEqual((3, 8), np.shape(ws2["integrate"].values))
         self.assertAlmostEqual(
-            max(ws2["proc"].values.real[1]), 6170.447249940133, places=4
+            max(ws2["integrate"].values.real[1]), 6170.447249940133, places=4
         )
         self.assertAlmostEqual(
-            min(ws2["proc"].values.real[1]), -7188.897892203664, places=4
+            min(ws2["integrate"].values.real[1]), -7188.897892203664, places=4
         )
 
         dnp.dnpTools.integrate(
             ws3, dim="f2", integrate_center=[-10, 0, 10], integrate_width=[10, 50, 10]
         )
-        self.assertEqual((3, 8), np.shape(ws2["proc"].values))
+        self.assertEqual((3, 8), np.shape(ws2["integrate"].values))
         self.assertAlmostEqual(
-            max(ws3["proc"].values.real[1]), 6170.447249940133, places=4
+            max(ws3["integrate"].values.real[1]), 6170.447249940133, places=4
         )
         self.assertAlmostEqual(
-            min(ws3["proc"].values.real[1]), -7188.897892203664, places=4
+            min(ws3["integrate"].values.real[1]), -7188.897892203664, places=4
         )
 
     def test_mr_properties(self):

--- a/unittests/test_import_wrapper.py
+++ b/unittests/test_import_wrapper.py
@@ -11,21 +11,20 @@ class load_wrapper_tester(unittest.TestCase):
             ".", "data", "vnmrj", "10mM_tempol_in_water_array.fid"
         )
 
-
         self.list_prospa_dir = [
-                './data/prospa/toluene_10mM_Tempone/1/data.1d',
-                './data/prospa/toluene_10mM_Tempone/2/data.1d',
-                './data/prospa/toluene_10mM_Tempone/3/data.1d',
-                './data/prospa/toluene_10mM_Tempone/4/data.1d',
-                './data/prospa/toluene_10mM_Tempone/5/data.1d',
-                './data/prospa/toluene_10mM_Tempone/6/data.1d',
-                './data/prospa/toluene_10mM_Tempone/7/data.1d',
-                './data/prospa/toluene_10mM_Tempone/8/data.1d',
-                './data/prospa/toluene_10mM_Tempone/9/data.1d',
-                './data/prospa/toluene_10mM_Tempone/10/data.1d',
-                ]
+            "./data/prospa/toluene_10mM_Tempone/1/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/2/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/3/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/4/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/5/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/6/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/7/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/8/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/9/data.1d",
+            "./data/prospa/toluene_10mM_Tempone/10/data.1d",
+        ]
         self.list_index = range(10)
-        self.dim_name = 'test_dim'
+        self.dim_name = "test_dim"
 
     def test_topspin(self):
         data = load(os.path.join(self.topspin_dir, str(1)), data_type="topspin")
@@ -41,7 +40,12 @@ class load_wrapper_tester(unittest.TestCase):
         load(self.vnmrj_dir, data_type="vnmrj")
 
     def test_import_list(self):
-        load(self.list_prospa_dir, data_type = "prospa", dim = self.dim_name, coord = self.list_index)
+        load(
+            self.list_prospa_dir,
+            data_type="prospa",
+            dim=self.dim_name,
+            coord=self.list_index,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] closes issue #100 
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] integrate, fit, and calculate_enhancement add new keys instead of replace "proc". functions adjusted accordingly to default look for 'integrals' (dnpNMR.calculate_enhancement and dnpFit.exponential_fit) or look for 'enhancements' (dnpFit.enhancement_fit), GUI updated to handle new behavior of integrate
