### PR TITLE
Improved printable representation of dnpdata objects

### DIFF
--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -79,11 +79,9 @@ class dnpdata(nddata.nddata_core):
 
         string += "attrs:\n"
 
-        max_attrs = 5
-
         for ix, key in enumerate(self.attrs.keys()):
-            if ix == max_attrs:
-                string += "\t+%i attrs" % (len(self.attrs) - max_attrs)
+            if ix == max_print_attrs:
+                string += "\t+%i attrs" % (len(self.attrs) - max_print_attrs)
                 break
             string += "\t{!r}: {!r}\n".format(key, self.attrs[key])
 

--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -14,6 +14,7 @@ core_attrs_list = ["nmr_frequency"]
 
 np.set_printoptions(threshold=15)
 
+
 class dnpdata(nddata.nddata_core):
     """
     dnpdata Class for handling dnp data
@@ -69,7 +70,7 @@ class dnpdata(nddata.nddata_core):
         string += " {} ({})\n".format(type(self.values).__name__, self.values.dtype)
 
         if self.print_values is True:
-            string += str(self.values) + '\n'
+            string += str(self.values) + "\n"
 
         string += "dims:\n\t"
 

--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -15,6 +15,7 @@ core_attrs_list = ["nmr_frequency"]
 np.set_printoptions(threshold=15)
 
 
+
 class dnpdata(nddata.nddata_core):
     """
     dnpdata Class for handling dnp data

--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -15,7 +15,6 @@ core_attrs_list = ["nmr_frequency"]
 np.set_printoptions(threshold=15)
 
 
-
 class dnpdata(nddata.nddata_core):
     """
     dnpdata Class for handling dnp data

--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -45,6 +45,8 @@ class dnpdata(nddata.nddata_core):
         super().__init__(values, dims, coords, attrs)
         self.version = version
         self.proc_attrs = []
+        self.max_print_attrs = 5
+        self.print_values = False
 
     @property
     def _constructor(self):
@@ -68,6 +70,9 @@ class dnpdata(nddata.nddata_core):
 
         string += " {} ({})\n".format(type(self.values).__name__, self.values.dtype)
 
+        if self.print_values is True:
+            string += str(self.values) + '\n'
+
         string += "dims:\n\t"
 
         string += "{}\n".format(self.dims)
@@ -80,8 +85,8 @@ class dnpdata(nddata.nddata_core):
         string += "attrs:\n"
 
         for ix, key in enumerate(self.attrs.keys()):
-            if ix == max_print_attrs:
-                string += "\t+%i attrs" % (len(self.attrs) - max_print_attrs)
+            if ix == self.max_print_attrs:
+                string += "\t+%i attrs" % (len(self.attrs) - self.max_print_attrs)
                 break
             string += "\t{!r}: {!r}\n".format(key, self.attrs[key])
 

--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -5,16 +5,14 @@ from collections.abc import MutableMapping
 
 import numpy as np
 
-from dnplab.core import nddata
+from .core import nddata
+from .version import __version__
 
-version = "1.0"
+version = __version__
 
 core_attrs_list = ["nmr_frequency"]
 
-max_print_attrs = 5
-
 np.set_printoptions(threshold=15)
-
 
 class dnpdata(nddata.nddata_core):
     """


### PR DESCRIPTION
- [x] passed `pytest .`
- [x] passes `black .`
- [x] Improved string printed for dnpdata and dnpdata_collection objects
