### PR TITLE
Fix Unsolicited Output in Documentation

### DIFF
--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -180,7 +180,6 @@ def exponential_fit(
 
     if isDict:
         all_data["fit"] = fit_data
-        return all_data
     else:
         return fit_data
 
@@ -246,7 +245,6 @@ def enhancement_fit(dataDict):
 
     if isDict:
         dataDict["fit"] = fit_data
-        return dataDict
     else:
         return fit_data
 

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -118,7 +118,6 @@ def align(all_data, dim="f2", dim2=None):
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 
@@ -285,7 +284,6 @@ def autophase(
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 
@@ -519,7 +517,6 @@ def calculate_enhancement(
 
     if isDict:
         all_data["enhancements"] = enhancement_data
-        return all_data
     else:
         return enhancement_data
 
@@ -591,7 +588,6 @@ def fourier_transform(
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 
@@ -663,7 +659,6 @@ def inverse_fourier_transform(
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 
@@ -699,7 +694,6 @@ def left_shift(all_data, dim="t2", shift_points=0):
 
     if isDict:
         all_data[all_data.processing_buffer] = shifted_data
-        return all_data
     else:
         return shifted_data
 
@@ -744,7 +738,6 @@ def remove_offset(all_data, dim="t2", offset_points=10):
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 
@@ -870,7 +863,6 @@ def window(
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -192,7 +192,6 @@ def baseline(
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data
 
@@ -305,7 +304,6 @@ def integrate(
 
     if isDict:
         all_data["integrals"] = integrate_data
-        return all_data
     else:
         return integrate_data
 
@@ -615,6 +613,5 @@ def signal_to_noise(
 
     if isDict:
         all_data[all_data.processing_buffer] = data
-        return all_data
     else:
         return data

--- a/unittests/test_dnpFit.py
+++ b/unittests/test_dnpFit.py
@@ -19,14 +19,14 @@ class dnpFit_tester(unittest.TestCase):
         self.ws.copy("raw", "proc")
 
     def test_fit_functions(self):
-        self.ws = nmr.remove_offset(self.ws)
-        self.ws = nmr.window(self.ws, type="lorentz_gauss", linewidth=[5, 10])
-        self.ws = nmr.fourier_transform(self.ws, zero_fill_factor=2)
-        self.ws = nmr.autophase(self.ws, method="search", order="zero")
-        self.ws = tools.baseline(
+        nmr.remove_offset(self.ws)
+        nmr.window(self.ws, type="lorentz_gauss", linewidth=[5, 10])
+        nmr.fourier_transform(self.ws, zero_fill_factor=2)
+        nmr.autophase(self.ws, method="search", order="zero")
+        tools.baseline(
             self.ws, type="polynomial", order=2, reference_slice=None
         )
-        self.ws = tools.integrate(
+        tools.integrate(
             self.ws, dim="f2", integrate_center=0, integrate_width=50
         )
         efit.exponential_fit(self.ws, type="T1")

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -52,13 +52,13 @@ class dnpNMR_tester(unittest.TestCase):
         nmr.window(self.ws, type="hamming")
 
         self.ws.copy("temp", "proc")
-        self.ws = nmr.window(self.ws, type="hann")
+        nmr.window(self.ws, type="hann")
 
         self.ws.copy("temp", "proc")
         nmr.window(self.ws, type="lorentz_gauss", linewidth=[5, 10])
 
         self.ws.copy("temp", "proc")
-        self.ws = nmr.window(self.ws, type="hamming", linewidth=5, inverse=True)
+        nmr.window(self.ws, type="hamming", linewidth=5, inverse=True)
         self.ws.copy("temp", "proc")
         nmr.window(self.ws, type="sin2")
 

--- a/unittests/test_dnpTools.py
+++ b/unittests/test_dnpTools.py
@@ -70,7 +70,7 @@ class dnpTools_tester(unittest.TestCase):
         nmr.fourier_transform(ws, zero_fill_factor=2)
         nmr.autophase(ws, method="search")
 
-        ws = dnp.dnpTools.baseline(ws, type="polynomial", order=1, reference_slice=None)
+        dnp.dnpTools.baseline(ws, type="polynomial", order=1, reference_slice=None)
         self.assertEqual(shape_data, np.shape(ws))
         self.assertAlmostEqual(
             max(ws["proc"].values[:, 2].real), 29.894686521140628, places=4


### PR DESCRIPTION
- [x] closes issue #xxxx
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] Fixes unsolicited output in documentation
