### PR TITLE
dnpdata now accepts values as type list

### DIFF
--- a/dnplab/core/nddata.py
+++ b/dnplab/core/nddata.py
@@ -22,6 +22,10 @@ class nddata_core(object):
 
         self._nddata_core_version = _nddata_core_version
 
+        # if values is list, convert to numpy array
+        if isinstance(values, list):
+            values = np.array(values)
+
         # verify values are numpy array
         if isinstance(values, np.ndarray):
             self._values = values


### PR DESCRIPTION
- [x] closes issue #60
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] what's new: dnpdata object now checks if values is list. If given as list, converts to numpy array
