### PR TITLE
fix len(coord) check in import; minor reformat in tests

### DIFF
--- a/dnplab/dnpImport.py
+++ b/dnplab/dnpImport.py
@@ -16,8 +16,10 @@ def load(path, data_type=None, dim=None, coord=None, *args, **kwargs):
     """
 
     if isinstance(path, list):
-        if coord and len(coord) != len(path):
-            raise ValueError("The length of coord must equal the number of paths given")
+        if len(coord) != len(path):
+            raise ValueError(
+                "coord must be a list or array equal in len to the number of paths given"
+            )
 
         data_list = []
         if dim is None:

--- a/unittests/test_dnpFit.py
+++ b/unittests/test_dnpFit.py
@@ -23,12 +23,8 @@ class dnpFit_tester(unittest.TestCase):
         nmr.window(self.ws, type="lorentz_gauss", linewidth=[5, 10])
         nmr.fourier_transform(self.ws, zero_fill_factor=2)
         nmr.autophase(self.ws, method="search", order="zero")
-        tools.baseline(
-            self.ws, type="polynomial", order=2, reference_slice=None
-        )
-        tools.integrate(
-            self.ws, dim="f2", integrate_center=0, integrate_width=50
-        )
+        tools.baseline(self.ws, type="polynomial", order=2, reference_slice=None)
+        tools.integrate(self.ws, dim="f2", integrate_center=0, integrate_width=50)
         efit.exponential_fit(self.ws, type="T1")
         self.assertAlmostEqual(self.ws["fit"].attrs["T1"], 2.140702947551208, places=4)
 


### PR DESCRIPTION
- [x] closes issue #xxxx
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] when coord is list, 'if coord' is ambiguous, this was removed in dnpImport line 19. Also a minor reformat in a test when black was run
