### PR TITLE
Removing commented code + reformatting

### DIFF
--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -68,28 +68,18 @@ def exponential_fit(
         attributes: "T1" value and "T1_stdd" standard deviation for type="T1", "T2" value and "T2_stdd" standard deviation for type="T2", "tau" and "tau_stdd" for type="mono", or "tau1", "tau1_stdd", "tau2", and "tau2_stdd" for type="bi"
     """
 
-    data, isDict = return_data(all_data)
+    data, isDict = return_data(
+        all_data,
+    )
 
-    if ws_key in all_data.keys():
+    if isDict:
         x_axis = all_data[ws_key].coords[dim]
-        new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
-        input_data = _np.real(all_data[ws_key].values)
-        ind_dim = dim
+        input_data = all_data[ws_key].real.values
     else:
-        if not indirect_dim:
-            if len(data.dims) == 2:
-                ind_dim = list(set(data.dims) - set([dim]))[0]
-            elif len(data.dims) == 1:
-                ind_dim = data.dims[0]
-            else:
-                raise ValueError(
-                    "you must specify the indirect dimension, use argument indirect_dim= "
-                )
-        else:
-            ind_dim = indirect_dim
-        x_axis = data.coords[ind_dim]
-        new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
-        input_data = _np.real(data.values)
+        x_axis = data.coords[dim]
+        input_data = data.real.values
+
+    new_axis = _np.r_[_np.min(x_axis) : _np.max(x_axis) : 100j]
 
     if type == "T1":
 
@@ -106,7 +96,7 @@ def exponential_fit(
         stdd = _np.sqrt(_np.diag(cov))
         fit = dnpMath.t1_function(new_axis, out[0], out[1], out[2])
 
-        fit_data = dnpdata(fit, [new_axis], [ind_dim])
+        fit_data = dnpdata(fit, [new_axis], [dim])
         fit_data.attrs["T1"] = out[0]
         fit_data.attrs["T1_stdd"] = stdd[0]
         fit_data.attrs["M_0"] = out[1]
@@ -149,7 +139,7 @@ def exponential_fit(
         stdd = _np.sqrt(_np.diag(cov))
         fit = dnpMath.t2_function(new_axis, out[0], out[1], out[2])
 
-        fit_data = dnpdata(fit, [new_axis], [ind_dim])
+        fit_data = dnpdata(fit, [new_axis], [dim])
         fit_data.attrs["T2"] = out[1]
         fit_data.attrs["T2_stdd"] = stdd[1]
         fit_data.attrs["M_0"] = out[0]
@@ -170,7 +160,7 @@ def exponential_fit(
         stdd = _np.sqrt(_np.diag(cov))
         fit = dnpMath.monoexp_fit(new_axis, out[0], out[1], out[2])
 
-        fit_data = dnpdata(fit, [new_axis], [ind_dim])
+        fit_data = dnpdata(fit, [new_axis], [dim])
         fit_data.attrs["tau"] = out[2]
         fit_data.attrs["tau_stdd"] = stdd[2]
         fit_data.attrs["C1"] = out[0]
@@ -189,7 +179,7 @@ def exponential_fit(
         stdd = _np.sqrt(_np.diag(cov))
         fit = dnpMath.biexp_fit(new_axis, out[0], out[1], out[2], out[3], out[4])
 
-        fit_data = dnpdata(fit, [new_axis], [ind_dim])
+        fit_data = dnpdata(fit, [new_axis], [dim])
         fit_data.attrs["tau1"] = out[2]
         fit_data.attrs["tau1_stdd"] = stdd[2]
         fit_data.attrs["tau2"] = out[4]

--- a/dnplab/dnpIO/prospa.py
+++ b/dnplab/dnpIO/prospa.py
@@ -284,7 +284,10 @@ def prospa_coords(attrs, data_shape, experiment):
         if attrs["delaySpacing"] == "lin":
             T1 = np.linspace(T1_min_delay, T1_max_delay, T1_steps) / 1000.0
         elif attrs["delaySpacing"] == "log":
-            T1 = np.logspace(np.log10(T1_min_delay), np.log10(T1_max_delay), T1_steps) / 1000.0
+            T1 = (
+                np.logspace(np.log10(T1_min_delay), np.log10(T1_max_delay), T1_steps)
+                / 1000.0
+            )
         else:
             raise ValueError(
                 f"Unable to determine delaySpacing {attrs['delaySpacing']}"
@@ -306,7 +309,10 @@ def prospa_coords(attrs, data_shape, experiment):
         if attrs["delaySpacing"] == "lin":
             T1 = np.linspace(T1_min_delay, T1_max_delay, T1_steps) / 1000.0
         else:
-            T1 = np.logspace(np.log10(T1_min_delay), np.log10(T1_max_delay), T1_steps) / 1000.0
+            T1 = (
+                np.logspace(np.log10(T1_min_delay), np.log10(T1_max_delay), T1_steps)
+                / 1000.0
+            )
 
         dims.append("t1")
         coords.append(T1)

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -114,22 +114,22 @@ class TestHydration(unittest.TestCase):
         self.assertEqual(len(self.data["T1_powers"]), 5)
         self.assertEqual(len(self.data["T1_array"]), 5)
         self.assertEqual(len(result["interpolated_T1"]), 21)
-        self.assertAlmostEqual(min(result["interpolated_T1"]), 2.051727288206873)
+        self.assertAlmostEqual(min(result["interpolated_T1"]), 2.051727288206873, places = 6)
         self.assertAlmostEqual(max(result["interpolated_T1"]), 2.5383409868931706)
         self.assertEqual(len(result["ksigma_array"]), 21)
-        self.assertAlmostEqual(min(result["ksigma_array"]), 2.5002212753387965)
-        self.assertAlmostEqual(max(result["ksigma_array"]), 19.573744921860015)
+        self.assertAlmostEqual(min(result["ksigma_array"]), 2.5002212753387965, places = 6)
+        self.assertAlmostEqual(max(result["ksigma_array"]), 19.573744921860015, places = 6)
         self.assertEqual(len(result["ksigma_fit"]), 21)
-        self.assertAlmostEqual(min(result["ksigma_fit"]), 1.9391281665269349)
-        self.assertAlmostEqual(max(result["ksigma_fit"]), 19.17592802884648)
+        self.assertAlmostEqual(min(result["ksigma_fit"]), 1.9391281665269349, places = 6)
+        self.assertAlmostEqual(max(result["ksigma_fit"]), 19.17592802884648, places = 6)
         self.assertEqual(len(result["uncorrected_Ep"]), 21)
-        self.assertAlmostEqual(min(result["uncorrected_Ep"]), -2.90847384506599)
-        self.assertAlmostEqual(max(result["uncorrected_Ep"]), 0.7434984782673344)
+        self.assertAlmostEqual(min(result["uncorrected_Ep"]), -2.90847384506599, places = 6)
+        self.assertAlmostEqual(max(result["uncorrected_Ep"]), 0.7434984782673344, places = 6)
 
-        self.assertAlmostEqual(result["ksigma"], 20.17803815171555)
-        self.assertAlmostEqual(result["klow"], 1286.2512443126634)
-        self.assertAlmostEqual(result["tcorr"], 485.8952027395348)
-        self.assertAlmostEqual(result["Dlocal"], 3.01176054373284e-10)
+        self.assertAlmostEqual(result["ksigma"], 20.17803815171555, places = 6)
+        self.assertAlmostEqual(result["klow"], 1286.2512443126634, places = 6)
+        self.assertAlmostEqual(result["tcorr"], 485.8952027395348, places = 6)
+        self.assertAlmostEqual(result["Dlocal"], 3.01176054373284e-10, places = 6)
 
         self.assertTrue(
             [x in self.ws["hydration_results"].keys() for x in result.keys()]
@@ -146,38 +146,38 @@ class TestHydration(unittest.TestCase):
 
         self.assertEqual(len(self.ws["hydration_results"]["interpolated_T1"]), 21)
         self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["interpolated_T1"]), 2.0978389591800344
+            min(self.ws["hydration_results"]["interpolated_T1"]), 2.0978389591800344, places = 6
         )
         self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["interpolated_T1"]), 2.5855460713039324
+            max(self.ws["hydration_results"]["interpolated_T1"]), 2.5855460713039324, places = 6
         )
         self.assertEqual(len(self.ws["hydration_results"]["ksigma_array"]), 21)
         self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["ksigma_array"]), 3.0565812706454305
+            min(self.ws["hydration_results"]["ksigma_array"]), 3.0565812706454305, places = 6
         )
         self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["ksigma_array"]), 24.020476541485717
+            max(self.ws["hydration_results"]["ksigma_array"]), 24.020476541485717, places = 6
         )
         self.assertEqual(len(self.ws["hydration_results"]["ksigma_fit"]), 21)
         self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["ksigma_fit"]), 2.3390612006821225
+            min(self.ws["hydration_results"]["ksigma_fit"]), 2.3390612006821225, places = 6
         )
         self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["ksigma_fit"]), 24.280175919600392
+            max(self.ws["hydration_results"]["ksigma_fit"]), 24.280175919600392, places = 6
         )
         self.assertEqual(len(self.ws["hydration_results"]["uncorrected_Ep"]), 21)
         self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["uncorrected_Ep"]), -2.9084738857665413
+            min(self.ws["hydration_results"]["uncorrected_Ep"]), -2.9084738857665413, places = 6
         )
         self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["uncorrected_Ep"]), 0.7434984946695101
+            max(self.ws["hydration_results"]["uncorrected_Ep"]), 0.7434984946695101, places = 6
         )
 
         self.assertAlmostEqual(
-            self.ws["hydration_results"]["ksigma"], 73.98621213840886
+            self.ws["hydration_results"]["ksigma"], 73.98621213840886, places = 6
         )
         self.assertAlmostEqual(self.ws["hydration_results"]["klow"], 1494.0321716770457, places = 6)
-        self.assertAlmostEqual(self.ws["hydration_results"]["tcorr"], 230.5905102559904)
+        self.assertAlmostEqual(self.ws["hydration_results"]["tcorr"], 230.5905102559904), places = 6
         self.assertAlmostEqual(
-            self.ws["hydration_results"]["Dlocal"], 1.4987607235715452e-09
+            self.ws["hydration_results"]["Dlocal"], 1.4987607235715452e-09, places = 6
         )

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -177,7 +177,7 @@ class TestHydration(unittest.TestCase):
             self.ws["hydration_results"]["ksigma"], 73.98621213840886, places = 6
         )
         self.assertAlmostEqual(self.ws["hydration_results"]["klow"], 1494.0321716770457, places = 6)
-        self.assertAlmostEqual(self.ws["hydration_results"]["tcorr"], 230.5905102559904), places = 6
+        self.assertAlmostEqual(self.ws["hydration_results"]["tcorr"], 230.5905102559904, places = 6)
         self.assertAlmostEqual(
             self.ws["hydration_results"]["Dlocal"], 1.4987607235715452e-09, places = 6
         )

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -176,7 +176,7 @@ class TestHydration(unittest.TestCase):
         self.assertAlmostEqual(
             self.ws["hydration_results"]["ksigma"], 73.98621213840886
         )
-        self.assertAlmostEqual(self.ws["hydration_results"]["klow"], 1494.0321716770457)
+        self.assertAlmostEqual(self.ws["hydration_results"]["klow"], 1494.0321716770457, places = 6)
         self.assertAlmostEqual(self.ws["hydration_results"]["tcorr"], 230.5905102559904)
         self.assertAlmostEqual(
             self.ws["hydration_results"]["Dlocal"], 1.4987607235715452e-09


### PR DESCRIPTION
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] Fixed bug with exponential fit if using dnpdata object
