### PR TITLE
improve topspin importing; other minor fixes

### DIFF
--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -41,6 +41,10 @@ class dnpdata(nddata.nddata_core):
             dims (list): list of strings which are names of axes
             attrs (dict): dictionary of parameters
         """
+
+        if isinstance(dims[0], list):
+            dims = dims[0]
+
         super().__init__(values, dims, coords, attrs)
         self.version = version
         self.proc_attrs = []

--- a/dnplab/dnpHydration.py
+++ b/dnplab/dnpHydration.py
@@ -397,7 +397,7 @@ def odnp(inputs={}, constants={}):
         # M.T. Türke, M. Bennati, Phys. Chem. Chem. Phys. 13 (2011) 3630. &
         # J. Hyde, J. Chien, J. Freed, J. Chem. Phys. 48 (1968) 4211.
 
-    if isinstance(inputs["smax_model"], int) or isinstance(inputs["smax_model"], float):
+    if isinstance(inputs["smax_model"], (int, float)):
         # Option 3, manual input of smax
         if not (inputs["smax_model"] <= 1 and inputs["smax_model"] > 0):
             raise ValueError("smax must be a number between 0 and 1")

--- a/dnplab/dnpIO/topspin.py
+++ b/dnplab/dnpIO/topspin.py
@@ -262,9 +262,10 @@ def load_fid_ser(path, type="fid"):
     if type == "fid":
         output = _dnpdata(data, [t], ["t2"], importantParamsDict)
     elif type == "ser":
-        vdList = topspin_vdlist(path)
-        if len(vdList) == int(attrsDict["TD_2"]):
-            output = _dnpdata(data, [t, vdList], ["t2", "t1"], importantParamsDict)
+        vdlist = topspin_vdlist(path)
+        importantParamsDict["vdlist"] = vdlist
+        if len(vdlist) == int(attrsDict["TD_2"]):
+            output = _dnpdata(data, [t, vdlist], ["t2", "t1"], importantParamsDict)
         else:
             output = _dnpdata(
                 data,
@@ -301,17 +302,17 @@ def topspin_vdlist(path):
         "m": 1.0e-3,
         "k": 1.0e3,
     }
-    vdList = []
+    vdlist = []
     for line in lines:
         if line[-1] in unitDict:
             value = float(line[0:-1]) * unitDict[line[-1]]
-            vdList.append(value)
+            vdlist.append(value)
         else:
             value = float(line)
-            vdList.append(value)
+            vdlist.append(value)
 
-    vdList = _np.array(vdList)
-    return vdList
+    vdlist = _np.array(vdlist)
+    return vdlist
 
 
 def load_title(

--- a/dnplab/dnpIO/topspin.py
+++ b/dnplab/dnpIO/topspin.py
@@ -183,6 +183,8 @@ def load_acqu_proc(path="1", paramFilename="acqus", procNum=1):
                 attrsDict[lineSplit[0]] = float(lineSplit[1])
             except:
                 attrsDict[lineSplit[0]] = lineSplit[1]
+            # if lineSplit[0] in ["TD", "NS"]:
+            # print(lineSplit[0] + ": " + str(attrsDict[lineSplit[0]]))
 
     if paramFilename == "acqu" or paramFilename == "acqus":
         if not all(

--- a/dnplab/dnpImport.py
+++ b/dnplab/dnpImport.py
@@ -73,10 +73,10 @@ def load_file(path, data_type=None, *args, **kwargs):
     elif data_type == "specman":
         return dnpIO.specman.import_specman(path, *args, **kwargs)
 
-    elif data_type == "xepr" or data_type == "xenon":
+    elif data_type in ["xepr", "xenon"]:
         return dnpIO.bes3t.import_bes3t(path, *args, **kwargs)
 
-    elif data_type == "winepr" or data_type == "esp":
+    elif data_type in ["winepr", "esp"]:
         return dnpIO.winepr.import_winepr(path, *args, **kwargs)
 
     elif data_type == "h5":
@@ -103,9 +103,9 @@ def autodetect(test_path):
     path_exten = os.path.splitext(test_path)[1]
     if path_exten == ".DSC" or path_exten == ".DTA" or path_exten == ".YGF":
         type = "xepr"
-    elif path_exten == ".par" or path_exten == ".spc":
+    elif path_exten in [".par", ".spc"]:
         type = "winepr"
-    elif path_exten == ".d01" or path_exten == ".exp":
+    elif path_exten in [".d01", ".exp"]:
         type = "specman"
     elif path_exten == ".jdf":
         type = "delta"

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -256,15 +256,13 @@ def autophase(
         method = "manual"
 
     if method == "manual":
-        if order == "zero" and (isinstance(phase, float) or isinstance(phase, int)):
+        if order == "zero" and isinstance(phase, (int, float)):
             data.attrs["phase0"] = phase
-        elif order == "zero" and not (
-            isinstance(phase, float) or isinstance(phase, int)
-        ):
+        elif order == "zero" and not isinstance(phase, (int, float)):
             raise ValueError(
                 "for a zero order phase correction you must supply a single phase"
             )
-        elif order == "first" and (isinstance(phase, float) or isinstance(phase, int)):
+        elif order == "first" and isinstance(phase, (int, float)):
             data.attrs["phase0"] = phase
             order = "zero"
             warnings.warn(
@@ -418,12 +416,8 @@ def calculate_enhancement(
 
     else:
 
-        if (
-            isinstance(off_spectrum, dnpdata)
-            or isinstance(off_spectrum, dnpdata_collection)
-        ) and (
-            isinstance(on_spectra, dnpdata)
-            or isinstance(on_spectra, dnpdata_collection)
+        if isinstance(off_spectrum, (dnpdata, dnpdata_collection)) and isinstance(
+            on_spectra, (dnpdata, dnpdata_collection)
         ):
 
             data_off, is_ws_off = return_data(off_spectrum)
@@ -444,9 +438,9 @@ def calculate_enhancement(
                 int_width_off = "full"
                 int_width_on = "full"
             elif (
-                isinstance(integrate_width, list)
-                or isinstance(integrate_width, _np.ndarray)
-            ) and len(integrate_width) == 2:
+                isinstance(integrate_width, (list, _np.ndarray))
+                and len(integrate_width) == 2
+            ):
                 int_width_off = integrate_width[0]
                 int_width_on = integrate_width[1]
             elif isinstance(integrate_width, int):
@@ -460,9 +454,9 @@ def calculate_enhancement(
             if integrate_center == "max":
                 pass
             elif (
-                isinstance(integrate_center, list)
-                or isinstance(integrate_center, _np.ndarray)
-            ) and len(integrate_center) == 2:
+                isinstance(integrate_center, (list, _np.ndarray))
+                and len(integrate_center) == 2
+            ):
                 int_center_off = integrate_center[0]
                 int_center_on = integrate_center[1]
             elif isinstance(integrate_center, int):
@@ -535,9 +529,9 @@ def calculate_enhancement(
                 raise ValueError("data is 1D, enhancement will be equal to 1 !!")
 
             if (
-                isinstance(integrate_width, list)
-                or isinstance(integrate_width, _np.ndarray)
-            ) and len(integrate_width) > 1:
+                isinstance(integrate_width, (list, _np.ndarray))
+                and len(integrate_width) > 1
+            ):
                 raise ValueError(
                     "supply a single value for integrate_width, or use 'full'"
                 )
@@ -545,9 +539,9 @@ def calculate_enhancement(
                 raise ValueError("the only allowed integrate_width string is 'full'")
 
             if (
-                isinstance(integrate_center, list)
-                or isinstance(integrate_center, _np.ndarray)
-            ) and len(integrate_center) > 1:
+                isinstance(integrate_center, (list, _np.ndarray))
+                and len(integrate_center) > 1
+            ):
                 raise ValueError(
                     "supply a single value for integrate_center, or use 'max'"
                 )
@@ -928,7 +922,7 @@ def window(
     ) == 2:
         exp_lw = linewidth[0]
         gauss_lw = linewidth[1]
-    elif isinstance(linewidth, int) or isinstance(linewidth, float):
+    elif isinstance(linewidth, (int, float)):
         exp_lw = linewidth
         gauss_lw = linewidth
     else:

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -201,19 +201,18 @@ def integrate(
 
     if integrate_width == "full":
         pass
-    elif (isinstance(integrate_width, int) or isinstance(integrate_width, float)) and (
-        isinstance(integrate_center, int) or isinstance(integrate_center, float)
+    elif isinstance(integrate_width, (int, float)) and isinstance(
+        integrate_center, (int, float)
     ):
         integrateMin = integrate_center - np.abs(integrate_width) / 2.0
         integrateMax = integrate_center + np.abs(integrate_width) / 2.0
         data = data[dim, (integrateMin, integrateMax)]
 
     elif (
-        (isinstance(integrate_width, list) and isinstance(integrate_center, list))
-        and (all((isinstance(x, int) or isinstance(x, float)) for x in integrate_width))
-        and (
-            all((isinstance(x, int) or isinstance(x, float)) for x in integrate_center)
-        )
+        isinstance(integrate_width, list)
+        and isinstance(integrate_center, list)
+        and all((isinstance(x, (int, float)) for x in integrate_width))
+        and all((isinstance(x, (int, float)) for x in integrate_center))
     ):
         if len(integrate_width) != len(integrate_center):
             raise TypeError(
@@ -229,9 +228,10 @@ def integrate(
         for mx, mn in enumerate(integrateMin):
             data_new.append(data[dim, (mn, integrateMax[mx])])
     elif (
-        (isinstance(integrate_width, int) or isinstance(integrate_width, float))
+        isinstance(integrate_width, (int, float))
         and isinstance(integrate_center, list)
-    ) and (all((isinstance(x, int) or isinstance(x, float)) for x in integrate_center)):
+        and all((isinstance(x, (int, float)) for x in integrate_center))
+    ):
         integrateMin = []
         integrateMax = []
         for cent in integrate_center:
@@ -515,12 +515,10 @@ def signal_to_noise(
 
     data, isDict = return_data(all_data)
 
-    if signal_width == "full" and (
-        isinstance(signal_center, int) or isinstance(signal_center, float)
-    ):
+    if signal_width == "full" and isinstance(signal_center, (int, float)):
         s_data = data.real
-    elif (isinstance(signal_width, int) or isinstance(signal_width, float)) and (
-        isinstance(signal_center, int) or isinstance(signal_center, float)
+    elif isinstance(signal_width, (int, float)) and isinstance(
+        signal_center, (int, float)
     ):
         signalMin = signal_center - np.abs(signal_width) / 2.0
         signalMax = signal_center + np.abs(signal_width) / 2.0
@@ -533,18 +531,14 @@ def signal_to_noise(
     if noise_center == "default" and noise_width == "default":
         noise_width = 0.05 * (max(data.coords[dim]) - min(data.coords[dim]))
         noise_center = max(data.coords[dim]) - (np.abs(noise_width) / 2.0)
-    elif (
-        isinstance(noise_center, int) or isinstance(noise_center, float)
-    ) and noise_width == "default":
+    elif isinstance(noise_center, (int, float)) and noise_width == "default":
         noise_width = 0.05 * (max(data.coords[dim]) - min(data.coords[dim]))
         if noise_center + (np.abs(noise_width) / 2.0) > max(data.coords[dim]):
             noise_width = 2 * (max(data.coords[dim]) - noise_center)
-    elif (
-        isinstance(noise_width, int) or isinstance(noise_width, float)
-    ) and noise_center == "default":
+    elif isinstance(noise_width, (int, float)) and noise_center == "default":
         noise_center = max(data.coords[dim]) - (np.abs(noise_width) / 2.0)
-    elif (isinstance(noise_width, int) or isinstance(noise_width, float)) and (
-        isinstance(noise_center, int) or isinstance(noise_center, float)
+    elif isinstance(noise_width, (int, float)) and isinstance(
+        noise_center, (int, float)
     ):
         pass
     else:

--- a/unittests/test_dnpImport.py
+++ b/unittests/test_dnpImport.py
@@ -11,20 +11,6 @@ class import_topspin_tester(unittest.TestCase):
     def setUp(self):
         self.testdata = os.path.join(".", "data", "topspin")
 
-    def test_dir_data_type(self):
-        self.assertEqual(
-            "fid", topspin.dir_data_type(os.path.join(self.testdata, str(1)))
-        )
-        self.assertEqual(
-            "serPhaseCycle", topspin.dir_data_type(os.path.join(self.testdata, str(5)))
-        )
-        self.assertEqual(
-            "ser", topspin.dir_data_type(os.path.join(self.testdata, str(28)))
-        )
-        self.assertEqual(
-            "", topspin.dir_data_type(os.path.join(self.testdata, str(33)))
-        )
-
     def test_import_topspin_exp1_is_fid(self):
         data = wrapper.load(os.path.join(self.testdata, str(1)), data_type="topspin")
         self.assertEqual(data.dims[0], "t2")


### PR DESCRIPTION
- [x] closes issue #xxxx
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] topspin import now uses TD from the acqu2s file to define the second dimension instead of the length of the vdlist
- [x]  vdlist is kept in the attrs dict
- [x] dims is no longer a list of a list after certain processing steps that reduce the dimensionality of the data
- [x] minor syntax improvements in if isinstance(...) statements 
