### PR TITLE
3D data loading/processing, misc. cleanup and bug fixes

### DIFF
--- a/dnplab/__init__.py
+++ b/dnplab/__init__.py
@@ -1,4 +1,4 @@
-from .dnpData import dnpdata, dnpdata_collection, create_workspace
+from .dnpData import dnpdata, dnpdata_collection, create_workspace, return_data
 from .dnpImport import load
 from .dnpSave import save
 from .dnpNMR import *

--- a/dnplab/dnpData.py
+++ b/dnplab/dnpData.py
@@ -42,7 +42,7 @@ class dnpdata(nddata.nddata_core):
             attrs (dict): dictionary of parameters
         """
 
-        if isinstance(dims[0], list):
+        if len(dims) > 0 and isinstance(dims[0], list):
             dims = dims[0]
 
         super().__init__(values, dims, coords, attrs)

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -30,7 +30,6 @@ def exponential_fit(
     bounds=None,
     p0=None,
     dim="t1",
-    indirect_dim=None,
     ws_key="integrals",
 ):
     """Fits various forms of exponential functions
@@ -52,8 +51,6 @@ def exponential_fit(
     +---------------+-------+-------------+-----------------------------------------------------------------------------------+
     | parameter     | type  | default     | description                                                                       |
     +===============+=======+=============+===================================================================================+
-    | dim           | str   | "f2"        | dimension to fit down                                                             |
-    +---------------+-------+-------------+-----------------------------------------------------------------------------------+
     | type          | str   | "mono"      | "T1" for inversion recovery fit, "T2" for stretched exponential, "mono", or "bi"  |
     +---------------+-------+-------------+-----------------------------------------------------------------------------------+
     | stretch       | bool  | False       | if False "p" is set to 1, if True "p" is a fit parameter                          |
@@ -63,8 +60,6 @@ def exponential_fit(
     | p0            | list  | None        | initial guesses for fit parameters                                                |
     +---------------+-------+-------------+-----------------------------------------------------------------------------------+
     | dim           | str   | "t1"        | direct dimension                                                                  |
-    +---------------+-------+-------------+-----------------------------------------------------------------------------------+
-    | indirect_dim  | str   | None        | indirect dimension                                                                |
     +---------------+-------+-------------+-----------------------------------------------------------------------------------+
     | ws_key        | str   | "integrals" | if False "p" is set to 1, if True "p" is a fit parameter                          |
     +---------------+-------+-------------+-----------------------------------------------------------------------------------+
@@ -232,7 +227,7 @@ def exponential_fit(
         return fit_data
 
 
-def enhancement_fit(all_data, bounds=None, p0=None):
+def enhancement_fit(all_data, dim="power", bounds=None, p0=None):
     """Fits enhancement curves to return Emax and power and one half maximum saturation
 
     .. math::
@@ -241,12 +236,13 @@ def enhancement_fit(all_data, bounds=None, p0=None):
 
     Args:
         all_data (dnpdata, dict): data container
+        dim (str): name of power dimension
         bounds (tuple): bounds on fit parameters
         p0 (list): initial guesses for fit parameters
 
     Returns:
-        all_data (dnpdata, dict): Processed data in container, updated with fit data
-        attributes: Emax, Emax standard deviation, p_one_half, and p_one_half standard deviation
+        fit_data (dnpdata): Processed data in container, updated with fit data
+        attrs (dict): Emax, Emax standard deviation, p_one_half, and p_one_half standard deviation
 
     Example::
 
@@ -270,7 +266,7 @@ def enhancement_fit(all_data, bounds=None, p0=None):
     if "enhancements" not in all_data.keys():
         raise TypeError("please use dnpNMR.calculate_enhancement() first")
 
-    power_axes = all_data["enhancements"].coords["power"]
+    power_axes = all_data["enhancements"].coords[dim]
 
     input_data = _np.real(all_data["enhancements"].values)
 
@@ -298,7 +294,7 @@ def enhancement_fit(all_data, bounds=None, p0=None):
     stdd = _np.sqrt(_np.diag(cov))
     fit = dnpMath.buildup_function(power_axes, out[0], out[1])
 
-    fit_data = dnpdata(fit, [power_axes], ["power"])
+    fit_data = dnpdata(fit, [power_axes], [dim])
     fit_data.attrs["E_max"] = out[0]
     fit_data.attrs["E_max_stdd"] = stdd[0]
     fit_data.attrs["power_half"] = out[1]

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -1,5 +1,4 @@
-from . import dnpdata as dnpdata, dnpdata_collection
-from . import return_data
+from . import return_data, dnpdata, dnpdata_collection
 from . import dnpMath
 import numpy as _np
 from scipy.optimize import curve_fit

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -91,8 +91,12 @@ def exponential_fit(
     if type == "T1":
         if p0 is None:
             x0 = [1.0, input_data[-1], input_data[-1]]
-        else:
+        elif isinstance(p0, (list, tuple)) and len(p0) == 3:
             x0 = p0
+        else:
+            raise TypeError(
+                "p0 must be a list or tuple of length=3, see the T1 function"
+            )
 
         if bounds:
             out, cov = curve_fit(
@@ -115,8 +119,12 @@ def exponential_fit(
     elif type == "T2":
         if p0 is None:
             x0 = [input_data[0], 1.0, 1.0]
-        else:
+        elif isinstance(p0, (list, tuple)) and len(p0) == 3:
             x0 = p0
+        else:
+            raise TypeError(
+                "p0 must be a list or tuple of length=3, see the T2 function"
+            )
 
         if stretched:
             if bounds:
@@ -161,8 +169,12 @@ def exponential_fit(
     elif type == "mono":
         if p0 is None:
             x0 = [input_data[-1], 1.0, 100]
-        else:
+        elif isinstance(p0, (list, tuple)) and len(p0) == 3:
             x0 = p0
+        else:
+            raise TypeError(
+                "p0 must be a list or tuple of length=3, see the mono-exponential function"
+            )
 
         if bounds:
             out, cov = curve_fit(
@@ -185,8 +197,12 @@ def exponential_fit(
     elif type == "bi":
         if p0 is None:
             x0 = [input_data[-1], 1.0, 100, 1.0, 100]
-        else:
+        elif isinstance(p0, (list, tuple)) and len(p0) == 5:
             x0 = p0
+        else:
+            raise TypeError(
+                "p0 must be a list or tuple of length=5, see the bi-exponential function"
+            )
 
         if bounds:
             out, cov = curve_fit(
@@ -260,8 +276,10 @@ def enhancement_fit(all_data, bounds=None, p0=None):
 
     if p0 is None:
         x0 = [input_data[-1], 0.1]
-    else:
+    elif isinstance(p0, (list, tuple)) and len(p0) == 2:
         x0 = p0
+    else:
+        raise TypeError("p0 must be a list or tuple of length=2, see the emax function")
 
     if bounds:
         out, cov = curve_fit(

--- a/dnplab/dnpFit.py
+++ b/dnplab/dnpFit.py
@@ -1,26 +1,8 @@
 from . import dnpdata as dnpdata, dnpdata_collection
+from . import return_data
 from . import dnpMath
 import numpy as _np
 from scipy.optimize import curve_fit
-
-
-def return_data(all_data):
-
-    is_workspace = False
-    if isinstance(all_data, dnpdata):
-        data = all_data.copy()
-    elif isinstance(all_data, dict):
-        raise ValueError("Type dict is not supported")
-    elif isinstance(all_data, dnpdata_collection):
-        is_workspace = True
-        if all_data.processing_buffer in all_data.keys():
-            data = all_data[all_data.processing_buffer]
-        else:
-            raise ValueError("No data in processing buffer")
-    else:
-        raise ValueError("Data type not supported")
-
-    return data, is_workspace
 
 
 def exponential_fit(
@@ -263,12 +245,15 @@ def enhancement_fit(all_data, dim="power", bounds=None, p0=None):
 
     data, isDict = return_data(all_data)
 
-    if "enhancements" not in all_data.keys():
-        raise TypeError("please use dnpNMR.calculate_enhancement() first")
-
-    power_axes = all_data["enhancements"].coords[dim]
-
-    input_data = _np.real(all_data["enhancements"].values)
+    if isDict:
+        if "enhancements" not in all_data.keys():
+            raise TypeError("please use dnpNMR.calculate_enhancement() first")
+        else:
+            power_axes = all_data["enhancements"].coords[dim]
+            input_data = _np.real(all_data["enhancements"].values)
+    else:
+        power_axes = data.coords[dim]
+        input_data = _np.real(data.values)
 
     if p0 is None:
         x0 = [input_data[-1], 0.1]

--- a/dnplab/dnpIO/bes3t.py
+++ b/dnplab/dnpIO/bes3t.py
@@ -1,6 +1,6 @@
 import numpy as np
 import os
-from dnplab import dnpdata
+from .. import dnpdata
 import warnings
 
 

--- a/dnplab/dnpIO/bes3t.py
+++ b/dnplab/dnpIO/bes3t.py
@@ -17,23 +17,53 @@ def import_bes3t(path):
 
     pathexten = os.path.splitext(path)[1]
     path = os.path.splitext(path)[0]
+    path_xgf = "none"
     path_ygf = "none"
+    path_zgf = "none"
     if pathexten == ".DSC" or pathexten == ".DTA":
+        path_dsc = path + ".DSC"
+        path_dta = path + ".DTA"
+        if os.path.isfile(path + ".XGF"):
+            path_xgf = path + ".XGF"
+        if os.path.isfile(path + ".YGF"):
+            path_ygf = path + ".YGF"
+        if os.path.isfile(path + ".ZGF"):
+            path_zgf = path + ".ZGF"
+
+    elif pathexten == ".XGF":
+        path_xgf = path + ".XGF"
         path_dsc = path + ".DSC"
         path_dta = path + ".DTA"
         if os.path.isfile(path + ".YGF"):
             path_ygf = path + ".YGF"
+        if os.path.isfile(path + ".ZGF"):
+            path_zgf = path + ".ZGF"
 
     elif pathexten == ".YGF":
         path_ygf = path + ".YGF"
         path_dsc = path + ".DSC"
         path_dta = path + ".DTA"
+        if os.path.isfile(path + ".XGF"):
+            path_xgf = path + ".XGF"
+        if os.path.isfile(path + ".ZGF"):
+            path_zgf = path + ".ZGF"
+
+    elif pathexten == ".ZGF":
+        path_zgf = path + ".ZGF"
+        path_dsc = path + ".DSC"
+        path_dta = path + ".DTA"
+        if os.path.isfile(path + ".XGF"):
+            path_xgf = path + ".XGF"
+        if os.path.isfile(path + ".YGF"):
+            path_ygf = path + ".YGF"
 
     else:
-        raise TypeError("data file must be .DTA, .DSC, or .YGF")
+        raise TypeError("data file must be .DTA, .DSC, .YGF, or .ZGF")
 
     params = load_dsc(path_dsc)
-    values, coords, dims, attrs = load_dta(path_dta, path_ygf, params)
+    values, coords, dims, attrs = load_dta(
+        path_dta, path_xgf, path_ygf, path_zgf, params
+    )
 
     bes3t_data = dnpdata(values, coords, dims, attrs)
 
@@ -113,23 +143,25 @@ def load_dsc(path):
             elif "XTYP" in par:
                 xtyp = par.replace("XTYP", "").strip()
                 if xtyp == "IGD":
-                    params["sweep_type"] = "nonlinear"
+                    params["x_type"] = "nonlinear"
                 elif xtyp == "IDX":
-                    params["sweep_type"] = "linear"
+                    params["x_type"] = "linear"
 
-            elif "IRFMT" in par:
-                dfmt = par.replace("IRFMT", "").strip()
+            elif "XFMT" in par:
+                dfmt = par.replace("XFMT", "").strip()
                 if dfmt == "D":
-                    params["sweep_format"] = "float64"
+                    params["x_format"] = "float64"
                 elif dfmt == "F":
-                    params["sweep_format"] = "float32"
+                    params["x_format"] = "float32"
                 elif dfmt == "C":
-                    params["sweep_format"] = "int8"
+                    params["x_format"] = "int8"
                 elif dfmt == "S":
-                    params["sweep_format"] = "int16"
+                    params["x_format"] = "int16"
                 elif dfmt == "I":
-                    params["sweep_format"] = "int32"
+                    params["x_format"] = "int32"
 
+            elif "YNAM" in par:
+                y_domain = par.replace("YNAM", "").replace("'", "").strip()
             elif "YUNI" in par:
                 params["y_unit"] = par.replace("YUNI", "").replace("'", "").strip()
             elif "YPTS" in par:
@@ -141,27 +173,84 @@ def load_dsc(path):
             elif "YTYP" in par:
                 ytyp = par.replace("YTYP", "").strip()
                 if ytyp == "IGD":
-                    params["slice_type"] = "nonlinear"
+                    params["y_type"] = "nonlinear"
                 elif ytyp == "IDX":
-                    params["slice_type"] = "linear"
+                    params["y_type"] = "linear"
 
             elif "YFMT" in par:
-                yfmt = par.replace("YFMT", "").strip()
-                if yfmt == "D":
-                    params["slice_format"] = "float64"
-                elif yfmt == "F":
-                    params["slice_format"] = "float32"
-                elif yfmt == "C":
-                    params["slice_format"] = "int8"
-                elif yfmt == "S":
-                    params["slice_format"] = "int16"
-                elif yfmt == "I":
-                    params["slice_format"] = "int32"
+                dfmt = par.replace("YFMT", "").strip()
+                if dfmt == "D":
+                    params["y_format"] = "float64"
+                elif dfmt == "F":
+                    params["y_format"] = "float32"
+                elif dfmt == "C":
+                    params["y_format"] = "int8"
+                elif dfmt == "S":
+                    params["y_format"] = "int16"
+                elif dfmt == "I":
+                    params["y_format"] = "int32"
+
+            elif "ZNAM" in par:
+                z_domain = par.replace("ZNAM", "").replace("'", "").strip()
+            elif "ZUNI" in par:
+                params["z_unit"] = par.replace("ZUNI", "").replace("'", "").strip()
+            elif "ZPTS" in par:
+                params["z_points"] = int(par.replace("ZPTS", "").strip())
+            elif "ZMIN" in par:
+                params["z_min"] = float(par.replace("ZMIN", "").strip())
+            elif "ZWID" in par:
+                params["z_max"] = float(par.replace("ZWID", "").strip())
+            elif "ZTYP" in par:
+                ztyp = par.replace("ZTYP", "").strip()
+                if ztyp == "IGD":
+                    params["z_type"] = "nonlinear"
+                elif ztyp == "IDX":
+                    params["z_type"] = "linear"
+
+            elif "ZFMT" in par:
+                dfmt = par.replace("ZFMT", "").strip()
+                if dfmt == "D":
+                    params["z_format"] = "float64"
+                elif dfmt == "F":
+                    params["z_format"] = "float32"
+                elif dfmt == "C":
+                    params["z_format"] = "int8"
+                elif dfmt == "S":
+                    params["z_format"] = "int16"
+                elif dfmt == "I":
+                    params["z_format"] = "int32"
+
+            elif "IRFMT" in par:
+                dfmt = par.replace("IRFMT", "").strip()
+                if dfmt == "D":
+                    params["real_format"] = "float64"
+                elif dfmt == "F":
+                    params["real_format"] = "float32"
+                elif dfmt == "C":
+                    params["real_format"] = "int8"
+                elif dfmt == "S":
+                    params["real_format"] = "int16"
+                elif dfmt == "I":
+                    params["real_format"] = "int32"
+
+            elif "IIFMT" in par:
+                ifmt = par.replace("IIFMT", "").strip()
+                if ifmt == "D":
+                    params["imag_format"] = "float64"
+                elif ifmt == "F":
+                    params["imag_format"] = "float32"
+                elif ifmt == "C":
+                    params["imag_format"] = "int8"
+                elif ifmt == "S":
+                    params["imag_format"] = "int16"
+                elif ifmt == "I":
+                    params["imag_format"] = "int32"
 
             elif "IKKF" in par:
                 params["data_type"] = par.replace("IKKF", "").strip()
             elif "BSEQ" in par:
                 params["endian"] = par.replace("BSEQ", "").strip()
+
         except ValueError:
             continue
 
@@ -172,16 +261,35 @@ def load_dsc(path):
         params["pulse_attenuation"] = params["attenuation"]
         params.pop("attenuation", None)
 
+    if all(
+        [
+            y not in params.keys()
+            for y in ["real_format", "imag_format", "x_format", "y_format", "z_format"]
+        ]
+    ):
+        raise TypeError(
+            "data format unknown. None of IRFMT, IIFMT, XFMT, YFMT, ZFMT found in DSC"
+        )
+
+    for x in ["x", "y", "z"]:
+        if x + "_format" not in params.keys():
+            if params["data_type"] == "REAL":
+                params[x + "_format"] = params["real_format"]
+            elif params["data_type"] == "CPLX":
+                params[x + "_format"] = params["imag_format"]
+
     return params
 
 
-def load_dta(path_dta, path_ygf, params):
+def load_dta(path_dta, path_xgf=None, path_ygf=None, path_zgf=None, params={}):
     """
-    Import data from .DTA file, and from .YGF file if one exists
+    Import data from .DTA file. Uses .DSC and .XGF, .YGF, or .ZGF files if they exists
 
     Args:
         path_dta (str) : Path to .DTA file
-        path_ygf (str) : path to .YGF file for 2D data, "none" if 1D or linear indirect axis
+        path_xgf (str) : path to .XGF file for 1D data with nonlinear axis, "none" otherwise
+        path_ygf (str) : path to .YGF file for 2D data, "none" if 1D or linear y axis
+        path_zgf (str) : path to .ZGF file for 3D data, "none" if 1D/2D or linear z axis
         params (dict) : dictionary of parameters
 
     Returns:
@@ -191,18 +299,31 @@ def load_dta(path_dta, path_ygf, params):
         dims (list) : dimensions
     """
 
-    dta_dtype = np.dtype(params["sweep_format"]).newbyteorder(params["endian"])
+    dta_dtype = np.dtype(params["x_format"]).newbyteorder(params["endian"])
     file_opened = open(path_dta, "rb")
     file_bytes = file_opened.read()
     file_opened.close()
     spec = np.frombuffer(file_bytes, dtype=dta_dtype)
-    abscissa = [
-        np.linspace(
-            params["x_min"],
-            params["x_min"] + params["x_width"],
-            params["x_points"],
-        )
-    ]
+    if params["x_type"] == "nonlinear":
+        abscissa = [
+            load_gf_files(
+                path_xgf,
+                axis_type=params["x_type"],
+                axis_format=params["x_format"],
+                axis_points=params["x_points"],
+                axis_min=params["x_min"],
+                axis_max=params["x_max"],
+                endian=params["endian"],
+            )
+        ]
+    elif params["x_type"] == "linear":
+        abscissa = [
+            np.linspace(
+                params["x_min"],
+                params["x_min"] + params["x_width"],
+                params["x_points"],
+            )
+        ]
 
     if "x_unit" not in params.keys() or params["x_unit"] in [
         "s",
@@ -223,9 +344,14 @@ def load_dta(path_dta, path_ygf, params):
         dims = ["t2"]
 
     if params["data_type"] == "CPLX":
-        spec = spec.astype(dtype=params["sweep_format"]).view(dtype=np.dtype("complex"))
+        spec = spec.astype(dtype=params["imag_format"]).view(dtype=np.dtype("complex"))
+    elif params["data_type"] == "REAL":
+        spec = spec.astype(dtype=params["real_format"]).view()
 
-    if "y_points" in params.keys() and params["y_points"] != 1:
+    if (
+        "z_points" not in params.keys()
+        or ("z_points" in params.keys() and params["z_points"] == 1)
+    ) and ("y_points" in params.keys() and params["y_points"] != 1):
         spec = np.reshape(spec, (params["x_points"], params["y_points"]), order="F")
 
         if "y_unit" in params.keys():
@@ -234,34 +360,104 @@ def load_dta(path_dta, path_ygf, params):
             dims.append("t1")
 
         abscissa.append(
-            np.linspace(params["y_min"], params["y_max"], params["y_points"])
+            load_gf_files(
+                path_ygf,
+                axis_type=params["y_type"],
+                axis_format=params["y_format"],
+                axis_points=params["y_points"],
+                axis_min=params["y_min"],
+                axis_max=params["y_max"],
+                endian=params["endian"],
+            )
         )
 
-        """
-        if path_ygf != "none":
-            if params["slice_type"] == "linear":
-                warnings.warn("axis is linear, confirm that indirect axis is correct")
-            ygf_type = np.dtype(params["slice_format"]).newbyteorder(params["endian"])
-            file_opened = open(path_ygf, "rb")
-            file_bytes = file_opened.read()
-            file_opened.close()
-            abscissa.append(np.frombuffer(file_bytes, dtype=ygf_type))
-        elif path_ygf == "none":
-            if params["slice_type"] == "nonlinear":
-                warnings.warn(
-                    "axis is nonlinear, confirm that .YGF file is not needed and indirect axis is correct"
-                )
-            abscissa.append(
-                np.linspace(params["y_min"], params["y_max"], params["y_points"])
-            )
+    elif "z_points" in params.keys() and params["z_points"] != 1:
+        spec = np.reshape(
+            spec,
+            (params["x_points"], params["y_points"]),
+            params["z_points"],
+            order="F",
+        )
+
+        if "y_unit" in params.keys():
+            dims.append(params["y_unit"])
         else:
-            warnings.warn("indirect axis format not supported, axis is only indexed")
-            abscissa.append([range(params["y_points"])])
-        """
+            dims.append("t1")
+
+        if "z_unit" in params.keys():
+            dims.append(params["z_unit"])
+        else:
+            dims.append("t0")
+
+        abscissa.append(
+            load_gf_files(
+                path_ygf,
+                axis_type=params["y_type"],
+                axis_format=params["y_format"],
+                axis_points=params["y_points"],
+                axis_min=params["y_min"],
+                axis_max=params["y_max"],
+                endian=params["endian"],
+            )
+        )
+        abscissa.append(
+            load_gf_files(
+                path_zgf,
+                axis_type=params["z_type"],
+                axis_format=params["z_format"],
+                axis_points=params["z_points"],
+                axis_min=params["z_min"],
+                axis_max=params["z_max"],
+                endian=params["endian"],
+            )
+        )
 
     params.pop("endian", None)
-    params.pop("sweep_format", None)
-    params.pop("slice_format", None)
+    params.pop("x_format", None)
+    params.pop("y_format", None)
+    params.pop("z_format", None)
+    params.pop("real_format", None)
+    params.pop("imag_format", None)
     params.pop("data_type", None)
 
     return spec, abscissa, dims, params
+
+
+def load_gf_files(
+    path, axis_type="", axis_format="", axis_points=1, axis_min=1, axis_max=1, endian=""
+):
+    """
+    Import data from .XGF, .YGF, or .ZGF files
+
+    Args:
+        path (str) : Path to ._GF file
+        axis_type (str) : linear or nonlinear
+        axis_format (str) : format of file data
+        axis_points (int) : number of points in axis
+        axis_min (float) : minimum value of axis
+        axis_max (float) : maximum value of axis
+        endian (float) : endian of data
+
+    Returns:
+        abscissa (ndarray) : axis coordinates
+    """
+
+    if path != "none":
+        if axis_type == "linear":
+            warnings.warn("axis format is linear, confirm that the axis is correct")
+        gf_type = np.dtype(axis_format).newbyteorder(endian)
+        file_opened = open(path, "rb")
+        file_bytes = file_opened.read()
+        file_opened.close()
+        abscissa = np.frombuffer(file_bytes, dtype=axis_format)
+    elif path == "none":
+        if axis_type == "nonlinear":
+            warnings.warn(
+                "axis is nonlinear, confirm that file is not needed and the axis is correct"
+            )
+        abscissa = np.linspace(axis_min, axis_max, axis_points)
+    else:
+        warnings.warn("axis format not supported, axis is only indexed")
+        abscissa = [range(axis_points)]
+
+    return abscissa

--- a/dnplab/dnpIO/delta.py
+++ b/dnplab/dnpIO/delta.py
@@ -1,6 +1,6 @@
 import numpy as np
 from struct import unpack
-from dnplab import dnpdata
+from .. import dnpdata
 
 
 def import_delta(path):

--- a/dnplab/dnpIO/power.py
+++ b/dnplab/dnpIO/power.py
@@ -1,17 +1,15 @@
 import numpy as _np
-from scipy.io import loadmat as _loadmat
-
-from .. import dnpData as _dnpData
+from scipy.io import loadmat
 
 
-def importPower(path, filename=""):
+def import_power(path, filename=""):
     """
     import powers file
     """
     fullPath = path + filename
 
     if fullPath[-4:] == ".mat":
-        rawDict = _loadmat(fullPath)
+        rawDict = loadmat(fullPath)
         t = rawDict["timelist"].reshape(-1)
         p = rawDict["powerlist"].reshape(-1)
 
@@ -27,7 +25,7 @@ def importPower(path, filename=""):
     return t, p
 
 
-def chopPower(t, p, threshold=0.1):
+def chop_power(t, p, threshold=0.1):
     """
     Use Derivative to chop Powers
     """
@@ -68,7 +66,7 @@ def chopPower(t, p, threshold=0.1):
     return averageTimeArray, averagePowerArray
 
 
-def assignPower(dataDict, expNumList, powersList):
+def assign_power(dataDict, expNumList, powersList):
     """
     Given a dictionary of dnpData objects with key being folder string,
     return the data with power values assigned to a new axis dimension

--- a/dnplab/dnpIO/specman.py
+++ b/dnplab/dnpIO/specman.py
@@ -110,7 +110,7 @@ def load_specman_d01(path, params):
 
     y_data = np.transpose(y_data)
 
-    dims_full = ["t", "x", "y", "z"]
+    dims_full = ["t2", "t1", "t0", "t"]
     dims = dims_full[0 : uint_read[2]]
     axes_lengths = uint_read[9:13]
 

--- a/dnplab/dnpIO/specman.py
+++ b/dnplab/dnpIO/specman.py
@@ -1,6 +1,6 @@
 import numpy as np
 import os
-from dnplab import dnpdata
+from .. import dnpdata
 
 
 def import_specman(path):

--- a/dnplab/dnpIO/tnmr.py
+++ b/dnplab/dnpIO/tnmr.py
@@ -1,4 +1,4 @@
-from dnplab import dnpdata
+from .. import dnpdata
 import numpy as np
 import struct
 import re

--- a/dnplab/dnpIO/topspin.py
+++ b/dnplab/dnpIO/topspin.py
@@ -248,6 +248,19 @@ def load_fid_ser(path, type="fid"):
     for a in attrsDict_list:
         attrsDict.update(a)
 
+    importantParamsDict = {
+        "nmr_frequency": attrsDict["SFO1"] * 1e6,
+        "SW_h": attrsDict["SW_h"],
+        "TD": attrsDict["TD"],
+    }
+
+    higher_dim_pars = {
+        x: attrsDict[x]
+        for x in ["SW_h_2", "TD_2", "SFO1_2", "SW_h_3", "TD_3", "SFO1_3"]
+        if x in attrsDict.keys()
+    }
+    importantParamsDict.update(higher_dim_pars)
+
     if attrsDict["BYTORDA"] == 0:
         endian = "<"
     else:
@@ -279,13 +292,11 @@ def load_fid_ser(path, type="fid"):
 
     data = data / attrsDict["RG"]
 
-    importantParamsDict = {"nmr_frequency": attrsDict["SFO1"] * 1e6}
-
     if type == "fid":
         output = _dnpdata(data, [t], ["t2"], importantParamsDict)
     elif type == "ser":
         vdlist = topspin_vdlist(path)
-        importantParamsDict["vdlist"] = vdlist
+        importantParamsDict["VDLIST"] = vdlist
         if len(vdlist) == int(attrsDict["TD_2"]):
             output = _dnpdata(data, [t, vdlist], ["t2", "t1"], importantParamsDict)
         else:

--- a/dnplab/dnpIO/topspin.py
+++ b/dnplab/dnpIO/topspin.py
@@ -204,6 +204,14 @@ def load_acqu_proc(path="1", paramFilename="acqus", procNum=1):
         else:
             attrsDict = {x + "_2": attrsDict[x] for x in attrsDict.keys()}
 
+    elif paramFilename == "acqu3" or paramFilename == "acqu3s":
+        if not all(map(attrsDict.keys().__contains__, ["SW_h", "TD", "SFO1"])):
+            raise KeyError(
+                "Unable to find all needed fields in the " + paramFilename + " file"
+            )
+        else:
+            attrsDict = {x + "_3": attrsDict[x] for x in attrsDict.keys()}
+
     return attrsDict
 
 

--- a/dnplab/dnpIO/topspin.py
+++ b/dnplab/dnpIO/topspin.py
@@ -90,31 +90,31 @@ _dspfvs_table_13 = {
 }
 
 
-def find_group_delay(attrsDict):
+def find_group_delay(attrs_dict):
     """
     Determine group delay from tables
 
     Args:
-        attrsDict (dict): dictionary of topspin acquisition parameters
+        attrs_dict (dict): dictionary of topspin acquisition parameters
 
     Returns:
         float: Group delay. Number of points FID is shifted by DSP. The ceiling of this number (group delay rounded up) is the number of points should be removed from the start of the FID.
     """
 
     group_delay = 0
-    if attrsDict["DSPFIRM"] != 0 and "GRPDLY" in attrsDict.keys():
-        group_delay = attrsDict["GRPDLY"]
-    elif attrsDict["DECIM"] == 1.0:
+    if attrs_dict["DSPFIRM"] != 0 and "GRPDLY" in attrs_dict.keys():
+        group_delay = attrs_dict["GRPDLY"]
+    elif attrs_dict["DECIM"] == 1.0:
         pass
     else:
-        if attrsDict["DSPFVS"] == 10:
-            group_delay = _dspfvs_table_10[int(attrsDict["DECIM"])]
-        elif attrsDict["DSPFVS"] == 11:
-            group_delay = _dspfvs_table_11[int(attrsDict["DECIM"])]
-        elif attrsDict["DSPFVS"] == 12:
-            group_delay = _dspfvs_table_12[int(attrsDict["DECIM"])]
-        elif attrsDict["DSPFVS"] == 13:
-            group_delay = _dspfvs_table_13[int(attrsDict["DECIM"])]
+        if attrs_dict["DSPFVS"] == 10:
+            group_delay = _dspfvs_table_10[int(attrs_dict["DECIM"])]
+        elif attrs_dict["DSPFVS"] == 11:
+            group_delay = _dspfvs_table_11[int(attrs_dict["DECIM"])]
+        elif attrs_dict["DSPFVS"] == 12:
+            group_delay = _dspfvs_table_12[int(attrs_dict["DECIM"])]
+        elif attrs_dict["DSPFVS"] == 13:
+            group_delay = _dspfvs_table_13[int(attrs_dict["DECIM"])]
         else:
             print(
                 "GRPDLY and DSPFVS parameters not found in acqus file, setting group delay to 0"
@@ -146,42 +146,42 @@ def import_topspin(path, phase_cycle=[0, 90, 180, 270]):
     return data
 
 
-def load_acqu_proc(path="1", paramFilename="acqus", procNum=1):
+def load_acqu_proc(path="1", param_filename="acqus", proc_num=1):
     """
     Import topspin acqu or proc files
 
     Args:
         path (str): directory of acqu or proc file
-        paramFilename (str): parameters filename
-        procNum (int): number of the folder inside the pdata folder
+        param_filename (str): parameters filename
+        proc_num (int): number of the folder inside the pdata folder
 
     Returns:
         dict: Dictionary of acqusition parameters
     """
 
-    if "proc" in paramFilename:
-        pathFilename = _os.path.join(path, "pdata", str(procNum), paramFilename)
+    if "proc" in param_filename:
+        path_filename = _os.path.join(path, "pdata", str(procNum), param_filename)
     else:
-        pathFilename = _os.path.join(path, paramFilename)
+        path_filename = _os.path.join(path, param_filename)
 
     # Import parameters
-    with open(pathFilename, "r") as f:
-        rawParams = f.read()
+    with open(path_filename, "r") as f:
+        raw_params = f.read()
 
     # Split parameters by line
-    lines = rawParams.strip("\n").split("\n")
-    attrsDict = {}
+    lines = raw_params.strip("\n").split("\n")
+    attrs_dict = {}
 
     # Parse Parameters
     for line in lines:
         if line[0:3] == "##$":
-            lineSplit = line[3:].split("= ")
+            line_split = line[3:].split("= ")
             try:
-                attrsDict[lineSplit[0]] = float(lineSplit[1])
+                attrs_dict[line_split[0]] = float(line_split[1])
             except:
-                attrsDict[lineSplit[0]] = lineSplit[1]
-            # if lineSplit[0] in ["TD", "NS"]:
-            # print(lineSplit[0] + ": " + str(attrsDict[lineSplit[0]]))
+                attrs_dict[line_split[0]] = line_split[1]
+            # if line_split[0] in ["TD", "NS"]:
+            # print(line_split[0] + ": " + str(attrs_dict[line_split[0]]))
 
     needed_params = [
         "SW_h",
@@ -194,36 +194,36 @@ def load_acqu_proc(path="1", paramFilename="acqus", procNum=1):
         "SFO1",
     ]
     needed_params_2 = ["SW_h", "TD", "SFO1"]
-    if paramFilename in ["acqu", "acqus"]:
+    if param_filename in ["acqu", "acqus"]:
         if not all(
             map(
-                attrsDict.keys().__contains__,
+                attrs_dict.keys().__contains__,
                 needed_params,
             )
         ):
             raise KeyError(
-                "Unable to find all needed fields in the " + paramFilename + " file"
+                "Unable to find all needed fields in the " + param_filename + " file"
             )
         else:
-            attrsDict = {x: attrsDict[x] for x in needed_params}
+            attrs_dict = {x: attrs_dict[x] for x in needed_params}
 
-    elif paramFilename in ["acqu2", "acqu2s"]:
-        if not all(map(attrsDict.keys().__contains__, needed_params_2)):
+    elif param_filename in ["acqu2", "acqu2s"]:
+        if not all(map(attrs_dict.keys().__contains__, needed_params_2)):
             raise KeyError(
-                "Unable to find all needed fields in the " + paramFilename + " file"
+                "Unable to find all needed fields in the " + param_filename + " file"
             )
         else:
-            attrsDict = {x + "_2": attrsDict[x] for x in needed_params_2}
+            attrs_dict = {x + "_2": attrs_dict[x] for x in needed_params_2}
 
-    elif paramFilename in ["acqu3", "acqu3s"]:
-        if not all(map(attrsDict.keys().__contains__, needed_params_2)):
+    elif param_filename in ["acqu3", "acqu3s"]:
+        if not all(map(attrs_dict.keys().__contains__, needed_params_2)):
             raise KeyError(
-                "Unable to find all needed fields in the " + paramFilename + " file"
+                "Unable to find all needed fields in the " + param_filename + " file"
             )
         else:
-            attrsDict = {x + "_3": attrsDict[x] for x in needed_params_2}
+            attrs_dict = {x + "_3": attrs_dict[x] for x in needed_params_2}
 
-    return attrsDict
+    return attrs_dict
 
 
 def load_fid_ser(path, type="fid", phase_cycle=None):
@@ -251,27 +251,27 @@ def load_fid_ser(path, type="fid", phase_cycle=None):
 
     dir_list = _os.listdir(path)
 
-    attrsDict_list = [
+    attrs_dict_list = [
         load_acqu_proc(path, x) for x in ["acqus", "acqu2s", "acqu3s"] if x in dir_list
     ]
-    attrsDict = {}
-    for a in attrsDict_list:
-        attrsDict.update(a)
+    attrs_dict = {}
+    for a in attrs_dict_list:
+        attrs_dict.update(a)
 
-    importantParamsDict = {
-        "nmr_frequency": attrsDict["SFO1"] * 1e6,
-        "SW_h": attrsDict["SW_h"],
-        "TD": attrsDict["TD"],
+    important_params_dict = {
+        "nmr_frequency": attrs_dict["SFO1"] * 1e6,
+        "SW_h": attrs_dict["SW_h"],
+        "TD": attrs_dict["TD"],
     }
 
     higher_dim_pars = {
-        x: attrsDict[x]
+        x: attrs_dict[x]
         for x in ["SW_h_2", "TD_2", "SFO1_2", "SW_h_3", "TD_3", "SFO1_3"]
-        if x in attrsDict.keys()
+        if x in attrs_dict.keys()
     }
-    importantParamsDict.update(higher_dim_pars)
+    important_params_dict.update(higher_dim_pars)
 
-    if attrsDict["BYTORDA"] == 0:
+    if attrs_dict["BYTORDA"] == 0:
         endian = "<"
     else:
         endian = ">"
@@ -283,73 +283,79 @@ def load_fid_ser(path, type="fid", phase_cycle=None):
 
     data = raw[0::2] + 1j * raw[1::2]  # convert to complex
 
-    group_delay = find_group_delay(attrsDict)
+    group_delay = find_group_delay(attrs_dict)
     group_delay = int(_np.ceil(group_delay))
 
-    t = 1.0 / attrsDict["SW_h"] * _np.arange(0, int(attrsDict["TD"] / 2) - group_delay)
+    t = (
+        1.0
+        / attrs_dict["SW_h"]
+        * _np.arange(0, int(attrs_dict["TD"] / 2) - group_delay)
+    )
 
     if "vdlist" in dir_list:
-        importantParamsDict.update({"VDLIST": topspin_vdlist(path)})
+        important_params_dict.update({"VDLIST": topspin_vdlist(path)})
 
     if type == "fid":
-        data = data[group_delay : int(attrsDict["TD"] / 2)] / attrsDict["RG"]
+        data = data[group_delay : int(attrs_dict["TD"] / 2)] / attrs_dict["RG"]
         coords = [t]
         dims = ["t2"]
     elif type == "ser":
-        ser_data = data.reshape(int(attrsDict["TD_2"]), -1).T
-        ser_data = ser_data[group_delay : int(attrsDict["TD"] / 2), :] / attrsDict["RG"]
-        coords = [t, range(int(attrsDict["TD_2"]))]
+        ser_data = data.reshape(int(attrs_dict["TD_2"]), -1).T
+        ser_data = (
+            ser_data[group_delay : int(attrs_dict["TD"] / 2), :] / attrs_dict["RG"]
+        )
+        coords = [t, range(int(attrs_dict["TD_2"]))]
         dims = ["t2", "t1"]
         if "acqu2s" in dir_list and "acqu3s" not in dir_list:
-            if "VDLIST" in importantParamsDict.keys():
-                if len(importantParamsDict["VDLIST"]) == int(attrsDict["TD_2"]):
-                    coords = [t, importantParamsDict["VDLIST"]]
+            if "VDLIST" in important_params_dict.keys():
+                if len(important_params_dict["VDLIST"]) == int(attrs_dict["TD_2"]):
+                    coords = [t, important_params_dict["VDLIST"]]
             else:
                 if isinstance(phase_cycle, list):
-                    length1d = int((_np.ceil(attrsDict["TD"] / 256.0) * 256) / 2)
+                    length1d = int((_np.ceil(attrs_dict["TD"] / 256.0) * 256) / 2)
                     ser_data = data.reshape(-1, int(length1d)).T
-                    ser_data = ser_data[group_delay : int(attrsDict["TD"] / 2), :]
+                    ser_data = ser_data[group_delay : int(attrs_dict["TD"] / 2), :]
                     phs_facs = _np.tile(
                         _np.array(phase_cycle),
-                        int(attrsDict["TD_2"]) / len(phase_cycle),
+                        int(attrs_dict["TD_2"]) / len(phase_cycle),
                     )
-                    for indx in range(int(attrsDict["TD_2"])):
+                    for indx in range(int(attrs_dict["TD_2"])):
                         ser_data[:, indx] = phs_facs[indx] * ser_data[:, indx]
-                    ser_data = ser_data.sum(axis=1) / attrsDict["RG"]
+                    ser_data = ser_data.sum(axis=1) / attrs_dict["RG"]
                     coords = [t]
                     dims = ["t2"]
 
         elif "acqu2s" in dir_list and "acqu3s" in dir_list:
             t = (
                 1.0
-                / attrsDict["SW_h"]
+                / attrs_dict["SW_h"]
                 * _np.arange(
-                    0, int(attrsDict["TD"] / 2 / int(attrsDict["TD_3"])) - group_delay
+                    0, int(attrs_dict["TD"] / 2 / int(attrs_dict["TD_3"])) - group_delay
                 )
             )
-            if "VDLIST" in importantParamsDict.keys() and len(
-                importantParamsDict["VDLIST"]
-            ) == int(attrsDict["TD_2"]):
+            if "VDLIST" in important_params_dict.keys() and len(
+                important_params_dict["VDLIST"]
+            ) == int(attrs_dict["TD_2"]):
                 coords = [
                     t,
-                    importantParamsDict["VDLIST"],
-                    range(int(attrsDict["TD_3"])),
+                    important_params_dict["VDLIST"],
+                    range(int(attrs_dict["TD_3"])),
                 ]
             else:
                 coords = [
                     t,
-                    range(int(attrsDict["TD_2"])),
-                    range(int(attrsDict["TD_3"])),
+                    range(int(attrs_dict["TD_2"])),
+                    range(int(attrs_dict["TD_3"])),
                 ]
             dims = ["t2", "t1", "t0"]
             ser_data = ser_data.reshape(
-                int(attrsDict["TD"] / 2 / int(attrsDict["TD_3"])),
-                int(attrsDict["TD_2"]),
-                int(attrsDict["TD_3"]),
+                int(attrs_dict["TD"] / 2 / int(attrs_dict["TD_3"])),
+                int(attrs_dict["TD_2"]),
+                int(attrs_dict["TD_3"]),
             )
         data = ser_data
 
-    return _dnpdata(data, coords, dims, importantParamsDict)
+    return _dnpdata(data, coords, dims, important_params_dict)
 
 
 def topspin_vdlist(path):
@@ -357,7 +363,7 @@ def topspin_vdlist(path):
     Return topspin vdlist
 
     Args:
-        Path (str): Directory of data
+        path (str): Directory of data
 
     Returns:
         numpy.ndarray: vdlist as numpy array
@@ -389,23 +395,23 @@ def topspin_vdlist(path):
 
 
 def load_title(
-    path="1" + _os.sep, titlePath=_os.path.join("pdata", "1"), titleFilename="title"
+    path="1", title_path=_os.path.join("pdata", "1"), title_filename="title"
 ):
     """
     Import Topspin Experiment Title File
 
     Args:
         path (str): Directory of title
-        titlePath (str): Path within experiment of title
-        titleFilename (str): filename of title
+        title_path (str): Path within experiment of title
+        title_filename (str): filename of title
 
     Returns:
         str: Contents of experiment title file
     """
 
-    pathFilename = _os.path.join(path, titlePath, titleFilename)
+    path_filename = _os.path.join(path, title_path, title_filename)
 
-    with open(pathFilename, "r") as f:
+    with open(path_filename, "r") as f:
         rawTitle = f.read()
     title = rawTitle.rstrip()
 

--- a/dnplab/dnpIO/winepr.py
+++ b/dnplab/dnpIO/winepr.py
@@ -1,6 +1,6 @@
 import numpy as np
 import os
-from dnplab import dnpdata
+from .. import dnpdata
 import warnings
 
 

--- a/dnplab/dnpIO/winepr.py
+++ b/dnplab/dnpIO/winepr.py
@@ -160,31 +160,16 @@ def load_spc(path, params):
         warnings.warn("unable to define axis, indexed only")
         abscissa = [range(params["x_points"])]
 
-    if "x_unit" not in params.keys() or params["x_unit"] in [
-        "s",
-        "ms",
-        "ns",
-        "ps",
-        "Time",
-        "time",
-    ]:
-        dims = ["t2"]
-    elif params["x_unit"] in ["G", "mT", "T", "Field", "field"]:
+    if "x_unit" in params.keys() and params["x_unit"] in ["G", "T"]:
         if params["x_unit"] == "G":
             abscissa = [x / 10 for x in abscissa]
         elif params["x_unit"] == "T":
             abscissa = [x * 1000 for x in abscissa]
-        dims = ["B0"]
-    else:
-        dims = ["t2"]
+    dims = ["t2"]
 
     if "y_points" in params.keys() and params["y_points"] != 1:
         spec = np.reshape(spec, (params["x_points"], params["y_points"]), order="F")
-
-        if "y_unit" in params.keys():
-            dims.append(params["y_unit"])
-        else:
-            dims.append("t1")
+        dims.append("t1")
 
         if "y_min" in params.keys() and "y_width" in params.keys():
             abscissa.append(

--- a/dnplab/dnpImport.py
+++ b/dnplab/dnpImport.py
@@ -1,7 +1,7 @@
 import os
 from . import dnpIO
 
-from .dnpTools import concat
+from .dnpData import concat
 
 
 def load(path, data_type=None, dim=None, coord=None, *args, **kwargs):

--- a/dnplab/dnpMath.py
+++ b/dnplab/dnpMath.py
@@ -276,7 +276,7 @@ def buildup_function(p, E_max, p_half):
     return E_max * p / (p_half + p)
 
 
-def baseline_fit(coords, values, type, order):
+def baseline_fit(coords, values, type, order, p0=None):
     """Fit a polynomial or exponential to a given coords and values pair
 
     Args:
@@ -294,11 +294,17 @@ def baseline_fit(coords, values, type, order):
     elif type == "exponential":
         values = values.real
         if order == 1:
-            x0 = [values[-1], values[0], 1]
+            if p0 is None:
+                x0 = [values[-1], values[0], 1]
+            else:
+                x0 = p0
             out, cov = curve_fit(monoexp_fit, coords, values, x0, method="lm")
             base_line = monoexp_fit(coords, out[0], out[1], out[2])
         elif order == 2:
-            x0 = [values[-1], values[0], 1, values[0], 1]
+            if p0 is None:
+                x0 = [values[-1], values[0], 1, values[0], 1]
+            else:
+                x0 = p0
             out, cov = curve_fit(biexp_fit, coords, values, x0, method="lm")
             base_line = biexp_fit(coords, out[0], out[1], out[2], out[3], out[4])
         else:

--- a/dnplab/dnpMath.py
+++ b/dnplab/dnpMath.py
@@ -1,26 +1,7 @@
 import numpy as _np
 
-from . import dnpdata, dnpdata_collection
+from . import return_data, dnpdata, dnpdata_collection
 from scipy.optimize import curve_fit
-
-
-def return_data(all_data):
-
-    is_workspace = False
-    if isinstance(all_data, dnpdata):
-        data = all_data.copy()
-    elif isinstance(all_data, dict):
-        raise ValueError("Type dict is not supported")
-    elif isinstance(all_data, dnpdata_collection):
-        is_workspace = True
-        if all_data.processing_buffer in all_data.keys():
-            data = all_data[all_data.processing_buffer]
-        else:
-            raise ValueError("No data in processing buffer")
-    else:
-        raise ValueError("Data type not supported")
-
-    return data, is_workspace
 
 
 def convert_power(watts=False, dBm=False, loss=0):

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -300,26 +300,13 @@ def autophase(
                 data.attrs["phase0"] + delta * (1 - pivot_ratio),
                 len(data.values),
             )
-        if len(shape_data) == 2:
-            for ix in range(shape_data[1]):
-                data.values[:, ix] *= _np.exp(-1j * data.attrs["phase1"])
-        else:
-            data.values *= _np.exp(-1j * data.attrs["phase1"])
+        data.values.T.dot(_np.exp(-1j * data.attrs["phase1"]))
+
     else:
         raise TypeError("Invalid order or order & phase pair")
 
     if force_positive:
-        if len(shape_data) == 2:
-            for ix in range(shape_data[1]):
-                if _np.sum(_np.real(data.values[:, ix])) < 0:
-                    data.values[:, ix] *= -1.0
-                else:
-                    pass
-        elif len(_np.shape(data.values)) == 1:
-            if _np.sum(_np.real(data.values)) < 0:
-                data.values *= -1.0
-        else:
-            raise ValueError("only 1D or 2D data are currently supported")
+        data.values = _np.absolute(data.values)
 
     proc_parameters = {
         "method": method,

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -380,12 +380,14 @@ def calculate_enhancement(
     _, isDict = return_data(all_data)
 
     if isDict and "integrals" in all_data.keys():
-        enh = (
+        enh = _np.array(
             all_data["integrals"].values.real
             / all_data["integrals"].values.real[off_spectrum - 1]
         )
         enhancement_data = dnpdata(
-            enh, [all_data["integrals"].coords], [all_data["integrals"].dims]
+            enh,
+            [all_data["integrals"].coords[x] for x in all_data["integrals"].dims],
+            all_data["integrals"].dims,
         )
 
     elif isinstance(off_spectrum, dnpdata) and isinstance(on_spectra, dnpdata):
@@ -445,8 +447,10 @@ def calculate_enhancement(
                 integrate_width=int_width_on,
             )
 
-            enh = on_data.values.real / off_data.values.real
-            enhancement_data = dnpdata(enh, [data_on.coords[dim]], [data_on.dims])
+            enh = _np.array(on_data.values.real / off_data.values.real)
+            enhancement_data = dnpdata(
+                enh, [on_data.coords[x] for x in on_data.dims], on_data.dims
+            )
 
         elif method == "amplitude":
             if integrate_center == "max":

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -1,13 +1,9 @@
 import warnings
 
 import numpy as _np
-from scipy.optimize import curve_fit
 
 from . import return_data, dnpdata, dnpdata_collection
 from . import dnpTools, dnpMath
-from . import dnpResults
-import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider, Button, RadioButtons
 
 import re
 import copy
@@ -325,6 +321,7 @@ def autophase(
 
     proc_parameters = {
         "method": method,
+        "reference_range": reference_range,
         "reference_slice": reference_slice,
         "force_positive": force_positive,
         "order": order,

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -283,13 +283,11 @@ def autophase(
                             _np.interp(
                                 phasing_x,
                                 check_data.coords[dim],
-                                check_data[dim, 0 : check_data.shape[index]].values[
-                                    :, indx
-                                ],
+                                check_data[dim, :].values[:, indx],
                             ).reshape(-1)
-                            for indx, _ in enumerate(indxer)
+                            for indx in range(indxer.size)
                         ]
-                    ).reshape(pts_lim, len(indxer))
+                    ).reshape(pts_lim, indxer.size)
             phases_0 = _np.linspace(-_np.pi / 2, _np.pi / 2, 180).reshape(-1)
             rotated_data = (temp_data.reshape(-1, 1)) * _np.exp(-1j * phases_0)
             real_imag_ratio = (_np.real(rotated_data) ** 2).sum(axis=0) / (

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -277,7 +277,8 @@ def autophase(
                             phasing_x, check_data.coords[dim], check_data.values
                         ).reshape(-1)
                     else:
-                        indxer = _np.argmax(check_data.values, axis=index)
+                        ind_dim = list(set(data.dims) - set([dim]))[0]
+                        ind_shape = data.shape[data.index(ind_dim)]
                         temp_data = _np.array(
                             [
                                 _np.interp(
@@ -285,9 +286,9 @@ def autophase(
                                     check_data.coords[dim],
                                     check_data[dim, :].values[:, indx],
                                 ).reshape(-1)
-                                for indx in range(indxer.size)
+                                for indx in range(ind_shape)
                             ]
-                        ).reshape(pts_lim, indxer.size)
+                        ).reshape(pts_lim, ind_shape)
             phases_0 = _np.linspace(-_np.pi / 2, _np.pi / 2, 180).reshape(-1)
             rotated_data = (temp_data.reshape(-1, 1)) * _np.exp(-1j * phases_0)
             real_imag_ratio = (_np.real(rotated_data) ** 2).sum(axis=0) / (

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -272,22 +272,22 @@ def autophase(
                         max(check_data.coords[dim]),
                         int(pts_lim),
                     ).reshape(-1)
-                if len(check_data.dims) == 1:
-                    temp_data = _np.interp(
-                        phasing_x, check_data.coords[dim], check_data.values
-                    ).reshape(-1)
-                else:
-                    indxer = _np.argmax(check_data.values, axis=index)
-                    temp_data = _np.array(
-                        [
-                            _np.interp(
-                                phasing_x,
-                                check_data.coords[dim],
-                                check_data[dim, :].values[:, indx],
-                            ).reshape(-1)
-                            for indx in range(indxer.size)
-                        ]
-                    ).reshape(pts_lim, indxer.size)
+                    if len(check_data.dims) == 1:
+                        temp_data = _np.interp(
+                            phasing_x, check_data.coords[dim], check_data.values
+                        ).reshape(-1)
+                    else:
+                        indxer = _np.argmax(check_data.values, axis=index)
+                        temp_data = _np.array(
+                            [
+                                _np.interp(
+                                    phasing_x,
+                                    check_data.coords[dim],
+                                    check_data[dim, :].values[:, indx],
+                                ).reshape(-1)
+                                for indx in range(indxer.size)
+                            ]
+                        ).reshape(pts_lim, indxer.size)
             phases_0 = _np.linspace(-_np.pi / 2, _np.pi / 2, 180).reshape(-1)
             rotated_data = (temp_data.reshape(-1, 1)) * _np.exp(-1j * phases_0)
             real_imag_ratio = (_np.real(rotated_data) ** 2).sum(axis=0) / (

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -184,9 +184,9 @@ def autophase(
     +=================+===============+===============+===================================================+
     | method          | str           | 'search'      | method of searching for the best phase            |
     +-----------------+---------------+---------------+---------------------------------------------------+
-    | pts_lim         | int or None   | None          | specify the max points used in phase search       |
-    +-----------------+---------------+---------------+---------------------------------------------------+
     | reference_range | list or tuple | None          | data window to use for phase calculation          |
+    +-----------------+---------------+---------------+---------------------------------------------------+
+    | pts_lim         | int or None   | None          | specify the max points used in phase search       |
     +-----------------+---------------+---------------+---------------------------------------------------+
     | order           | str           | 'zero'        | order of phase correction                         |
     +-----------------+---------------+---------------+---------------------------------------------------+
@@ -613,7 +613,7 @@ def inverse_fourier_transform(
     +------------------+------+-----------+--------------------------------------------------+
     | shift            | bool | True      | Perform fftshift to set zero frequency to center |
     +------------------+------+-----------+--------------------------------------------------+
-    | convert_to_ppm   | bool | True      | Convert dim from Hz to ppm                       |
+    | convert_from_ppm | bool | True      | Convert dim from Hz to ppm                       |
     +------------------+------+-----------+--------------------------------------------------+
     | output           | str  | 'complex' | output complex, magnitude, or power spectrum     |
     +------------------+------+-----------+--------------------------------------------------+

--- a/dnplab/dnpNMR.py
+++ b/dnplab/dnpNMR.py
@@ -376,7 +376,7 @@ def calculate_enhancement(
 
     _, isDict = return_data(all_data)
 
-    if isDict and "integrals" in all_data.keys():
+    if isDict and "integrals" in all_data.keys() and isinstance(off_spectrum, int):
         enh = _np.array(
             all_data["integrals"].values.real
             / all_data["integrals"].values.real[off_spectrum - 1]

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -59,8 +59,9 @@ def baseline(
         elif mode == "divide":
             data.values /= bline
     else:
-        indxer = np.argmax(data.values, axis=index)
-        bline_array = np.zeros(shape=(data.shape[index], indxer.size))
+        ind_dim = list(set(data.dims) - set([dim]))[0]
+        ind_shape = data.shape[data.index(ind_dim)]
+        bline_array = np.zeros(shape=(data.shape[index], ind_shape))
         if reference_slice is not None:
             bline = dnpMath.baseline_fit(
                 data.coords[dim],
@@ -69,10 +70,10 @@ def baseline(
                 order,
                 p0=p0,
             )
-            for ix in range(indxer.size):
+            for ix in range(ind_shape):
                 bline_array[:, ix] = bline.real
         elif reference_slice is None:
-            for ix in range(indxer.size):
+            for ix in range(ind_shape):
                 bline = dnpMath.baseline_fit(
                     data.coords[dim],
                     data[dim, :].values[:, ix],
@@ -83,7 +84,6 @@ def baseline(
                 bline_array[:, ix] = bline.real
         else:
             raise TypeError("invalid reference_slice")
-
         if mode == "subtract":
             data.values -= bline_array
         elif mode == "divide":
@@ -232,7 +232,8 @@ def integrate(
                 remaining_dims = ["width"] + remaining_dims
             data_values = np.array(data_integrals)
         elif isinstance(integrate_center, list) and isinstance(integrate_width, list):
-            indxer = np.argmax(data_new[0].values, axis=index)
+            ind_dim = list(set(data.dims) - set([dim]))[0]
+            ind_shape = data.shape[data.index(ind_dim)]
             remaining_coords = [
                 np.array(integrate_center),
                 np.array(integrate_width),
@@ -240,7 +241,7 @@ def integrate(
             remaining_dims = ["center", "width"] + remaining_dims
             data_values = np.array(
                 tuple([data_integrals for _ in range(len(data_integrals))])
-            ).reshape(len(data_integrals), len(data_integrals), indxer.size)
+            ).reshape(len(data_integrals), len(data_integrals), ind_shape)
     else:
         data_values = np.trapz(data_new.values, x=data_new.coords[dim], axis=index)
 

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -13,7 +13,7 @@ def baseline(
     dim="f2",
     type="polynomial",
     order=1,
-    initial_guess=None,
+    p0=None,
     mode="subtract",
     reference_slice=None,
 ):
@@ -30,6 +30,8 @@ def baseline(
     | type            | str  | 'polynomial'  | type of baseline fit                              |
     +-----------------+------+---------------+---------------------------------------------------+
     | order           | int  | 1             | polynomial order, or 1=mono 2=bi exponential      |
+    +-----------------+------+---------------+---------------------------------------------------+
+    | p0              | list | None          | initial guess for exponential baseline fit        |
     +-----------------+------+---------------+---------------------------------------------------+
     | mode            | str  | 'subtract'    | either 'subtract' or 'divide' by baseline         |
     +-----------------+------+---------------+---------------------------------------------------+
@@ -51,9 +53,7 @@ def baseline(
             reference_slice -= 1
 
     if len(data.dims) == 1:
-        bline = dnpMath.baseline_fit(
-            data.coords[dim], data.values, type, order, p0=initial_guess
-        )
+        bline = dnpMath.baseline_fit(data.coords[dim], data.values, type, order, p0=p0)
         if mode == "subtract":
             data.values -= bline
         elif mode == "divide":
@@ -67,7 +67,7 @@ def baseline(
                 data[dim, :].values[:, reference_slice],
                 type,
                 order,
-                p0=initial_guess,
+                p0=p0,
             )
             for ix in range(indxer.size):
                 bline_array[:, ix] = bline.real
@@ -78,7 +78,7 @@ def baseline(
                     data[dim, :].values[:, ix],
                     type,
                     order,
-                    p0=initial_guess,
+                    p0=p0,
                 )
                 bline_array[:, ix] = bline.real
         else:

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -80,7 +80,7 @@ def baseline(
 def integrate(
     all_data,
     dim="f2",
-    type="single",
+    type="trapz",
     integrate_center=0,
     integrate_width="full",
 ):
@@ -108,13 +108,12 @@ def integrate(
     data, isDict = return_data(all_data)
     index = data.index(dim)
 
+    data_new = data.copy()
     if type == "double":
         first_int = scipy.integrate.cumtrapz(
             data.values, x=data.coords[dim], axis=index, initial=0
         )
-        data_new = dnpdata(first_int, data.coords, data.dims)
-    else:
-        data_new = data.copy()
+        data_new.values = first_int
 
     if integrate_width == "full":
         pass
@@ -214,8 +213,12 @@ def integrate(
 
     integrate_data = dnpdata(data_values, remaining_coords, remaining_dims)
 
+    integrate_data.attrs["integrate_center"] = integrate_center
+    integrate_data.attrs["integrate_width"] = integrate_width
+
     if type == "double":
         integrate_data.attrs["first_integral"] = first_int
+        integrate_data.attrs["dim_coords"] = data.coords[dim]
 
     if isDict:
         all_data["integrals"] = integrate_data

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -537,21 +537,21 @@ def zero_fill(
     factor=2,
 ):
     """
-    Perform zero filling down dim dimension
+    Perform zero-filling (append) down given dimension
 
     Args:
-        all_data (dnpdata, dict): Data container
+        all_data (dnpdata): data object
 
     +------------------+------+-----------+--------------------------------------------------+
     | parameter        | type | default   | description                                      |
     +==================+======+===========+==================================================+
-    | dim              | str  | 't2'      | dimension to Fourier transform                   |
+    | dim              | str  | 't2'      | dimension to zero-fill                           |
     +------------------+------+-----------+--------------------------------------------------+
     | factor           | int  | 2         | factor to increase dim with zeros                |
     +------------------+------+-----------+--------------------------------------------------+
 
     Returns:
-        dnpdata: data object after zero fill
+        dnpdata: data object after zero-fill
     """
 
     data, isDict = return_data(all_data)

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -179,8 +179,8 @@ def integrate(
 
     remaining_dims = [x for x in data.dims if x != dim]
     if len(remaining_dims) == 0:
-        remaining_dims = []
-        remaining_coords = []
+        remaining_dims = ["index"]
+        remaining_coords = [np.array([0])]
     else:
         remaining_coords = [data.coords[x] for x in remaining_dims]
 
@@ -211,6 +211,9 @@ def integrate(
             ).reshape(len(data_integrals), len(data_integrals), data_new[0].shape[1])
     else:
         data_values = np.trapz(data_new.values, x=data_new.coords[dim], axis=index)
+
+    if not isinstance(data_values, (list, np.ndarray)):
+        data_values = [data_values]
 
     integrate_data = dnpdata(np.array(data_values), remaining_coords, remaining_dims)
 

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -1,4 +1,5 @@
-from . import dnpMath, dnpNMR, return_data, dnpdata, dnpdata_collection
+from . import return_data, dnpdata, dnpdata_collection
+from . import dnpMath, dnpNMR
 import numpy as np
 import scipy.integrate
 

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -13,6 +13,7 @@ def baseline(
     dim="f2",
     type="polynomial",
     order=1,
+    initial_guess=None,
     mode="subtract",
     reference_slice=None,
 ):
@@ -50,7 +51,9 @@ def baseline(
             reference_slice -= 1
 
     if len(data.dims) == 1:
-        bline = dnpMath.baseline_fit(data.coords[dim], data.values, type, order)
+        bline = dnpMath.baseline_fit(
+            data.coords[dim], data.values, type, order, p0=initial_guess
+        )
         if mode == "subtract":
             data.values -= bline
         elif mode == "divide":
@@ -60,14 +63,22 @@ def baseline(
         bline_array = np.zeros(shape=(data.shape[index], indxer.size))
         if reference_slice is not None:
             bline = dnpMath.baseline_fit(
-                data.coords[dim], data[dim, :].values[:, reference_slice], type, order
+                data.coords[dim],
+                data[dim, :].values[:, reference_slice],
+                type,
+                order,
+                p0=initial_guess,
             )
             for ix in range(indxer.size):
                 bline_array[:, ix] = bline.real
         elif reference_slice is None:
             for ix in range(indxer.size):
                 bline = dnpMath.baseline_fit(
-                    data.coords[dim], data[dim, :].values[:, ix], type, order
+                    data.coords[dim],
+                    data[dim, :].values[:, ix],
+                    type,
+                    order,
+                    p0=initial_guess,
                 )
                 bline_array[:, ix] = bline.real
         else:

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -534,16 +534,10 @@ def signal_to_noise(
 def zero_fill(
     all_data,
     dim="t2",
-    zero_fill_factor=2,
-    shift=True,
-    inverse=False,
-    convert_from_ppm=True,
+    factor=2,
 ):
-
-    """Perform zero filling down dim dimension
-
-    .. Note::
-        Assumes dt = t[1] - t[0]
+    """
+    Perform zero filling down dim dimension
 
     Args:
         all_data (dnpdata, dict): Data container
@@ -553,13 +547,7 @@ def zero_fill(
     +==================+======+===========+==================================================+
     | dim              | str  | 't2'      | dimension to Fourier transform                   |
     +------------------+------+-----------+--------------------------------------------------+
-    | zero_fill_factor | int  | 2         | factor to increase dim with zeros                |
-    +------------------+------+-----------+--------------------------------------------------+
-    | shift            | bool | True      | Perform fftshift to set zero frequency to center |
-    +------------------+------+-----------+--------------------------------------------------+
-    | inverse          | bool | False     | True means zero-fill in frequency domain         |
-    +------------------+------+-----------+--------------------------------------------------+
-    | convert_from_ppm | bool | True      | True if frequency axis is in ppm                 |
+    | factor           | int  | 2         | factor to increase dim with zeros                |
     +------------------+------+-----------+--------------------------------------------------+
 
     Returns:
@@ -567,48 +555,25 @@ def zero_fill(
     """
 
     data, isDict = return_data(all_data)
+    index = data.dims.index(dim)
 
-    # handle zero_fill_factor
-    if not isinstance(zero_fill_factor, int) or zero_fill_factor <= 0:
-        raise ValueError("zero_fill_factor must be type int greater than 0")
+    factor = int(factor)
+    if factor <= 0:
+        factor = 1
+
+    n_pts = data.shape[index] * factor
+    data.coords[dim] = np.linspace(data.coords[dim][0], data.coords[dim][-1], num=n_pts)
+
+    shape = list(data.shape)
+    shape[index] = n_pts - data.shape[index]
+    data.values = np.concatenate(
+        (data.values, np.zeros(shape=tuple(shape))), axis=index
+    )
 
     proc_parameters = {
         "dim": dim,
-        "zero_fill_factor": zero_fill_factor,
-        "shift": shift,
-        "inverse": inverse,
+        "factor": factor,
     }
-
-    if inverse:
-        df = data.coords[dim][1] - data.coords[dim][0]
-        if "nmr_frequency" not in data.attrs.keys():
-            warn(
-                "NMR frequency not found in the attrs dictionary, coversion to ppm requires the NMR frequency. See docs."
-            )
-        else:
-            if convert_from_ppm:
-                df /= -1 / (data.attrs["nmr_frequency"] / 1.0e6)
-
-        n_pts = zero_fill_factor * len(data.coords[dim])
-        data.coords[dim] = (1.0 / (n_pts * df)) * _np.r_[0:n_pts]
-
-        proc_parameters["convert_from_ppm"] = convert_from_ppm
-
-    else:
-        dt = data.coords[dim][1] - data.coords[dim][0]
-        n_pts = zero_fill_factor * len(data.coords[dim])
-        data.coords[dim] = (1.0 / (n_pts * dt)) * np.r_[0:n_pts]
-        if shift == True:
-            data.coords[dim] -= 1.0 / (2 * dt)
-
-    if len(data.shape) == 2:
-        temp = np.zeros((n_pts, data.shape[1]), dtype=np.complex)
-        temp[: data.shape[0], : data.shape[1]] = data.values
-    elif len(data.shape) == 1:
-        temp = np.zeros(n_pts, dtype=np.complex)
-        temp[: data.shape[0]] = data.values
-
-    data.values = temp
 
     proc_attr_name = "zero_fill"
     data.add_proc_attrs(proc_attr_name, proc_parameters)

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -178,8 +178,8 @@ def integrate(
 
     remaining_dims = [x for x in data.dims if x != dim]
     if len(remaining_dims) == 0:
-        remaining_dims = ["index"]
-        remaining_coords = [np.array([0])]
+        remaining_dims = []
+        remaining_coords = []
     else:
         remaining_coords = [data.coords[x] for x in remaining_dims]
 
@@ -211,7 +211,7 @@ def integrate(
     else:
         data_values = np.trapz(data_new.values, x=data_new.coords[dim], axis=index)
 
-    integrate_data = dnpdata(data_values, remaining_coords, remaining_dims)
+    integrate_data = dnpdata(np.array(data_values), remaining_coords, remaining_dims)
 
     integrate_data.attrs["integrate_center"] = integrate_center
     integrate_data.attrs["integrate_width"] = integrate_width

--- a/dnplab/dnpTools.py
+++ b/dnplab/dnpTools.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from . import return_data, dnpdata, dnpdata_collection
 from . import dnpMath, dnpNMR
 import numpy as np
@@ -39,7 +41,7 @@ def baseline(
     if reference_slice is not None:
         if len(np.shape(data.values)) == 1:
             reference_slice = None
-            warnings.warn("ignoring reference_slice, this is 1D data")
+            warn("ignoring reference_slice, this is 1D data")
         else:
             reference_slice -= 1
 
@@ -579,8 +581,13 @@ def zero_fill(
 
     if inverse:
         df = data.coords[dim][1] - data.coords[dim][0]
-        if convert_from_ppm:
-            df /= -1 / (data.attrs["nmr_frequency"] / 1.0e6)
+        if "nmr_frequency" not in data.attrs.keys():
+            warn(
+                "NMR frequency not found in the attrs dictionary, coversion to ppm requires the NMR frequency. See docs."
+            )
+        else:
+            if convert_from_ppm:
+                df /= -1 / (data.attrs["nmr_frequency"] / 1.0e6)
 
         n_pts = zero_fill_factor * len(data.coords[dim])
         data.coords[dim] = (1.0 / (n_pts * df)) * _np.r_[0:n_pts]

--- a/dnplab/dnpWidgets.py
+++ b/dnplab/dnpWidgets.py
@@ -1,28 +1,9 @@
 import numpy as _np
 
-from . import dnpdata, dnpdata_collection
+from . import return_data, dnpdata, dnpdata_collection
 
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, Button, RadioButtons
-
-
-def return_data(all_data):
-
-    is_workspace = False
-    if isinstance(all_data, dnpdata):
-        data = all_data.copy()
-    elif isinstance(all_data, dict):
-        raise ValueError("Type dict is not supported")
-    elif isinstance(all_data, dnpdata_collection):
-        is_workspace = True
-        if all_data.processing_buffer in all_data.keys():
-            data = all_data[all_data.processing_buffer]
-        else:
-            raise ValueError("No data in processing buffer")
-    else:
-        raise ValueError("Data type not supported")
-
-    return data, is_workspace
 
 
 def manual_align(all_data, dim):

--- a/dnplab/hydrationGUI.py
+++ b/dnplab/hydrationGUI.py
@@ -884,7 +884,7 @@ class hydrationGUI(QMainWindow):
         self.flname = os.path.normpath(flname)
         exten = self.flname.split(".")
 
-        if "h5" in exten or "mat" in exten:
+        if exten in ["h5", "mat"]:
             self.GUI_Result()
         else:
             self.NMR_Data()

--- a/docs/source/dnpHydration.rst
+++ b/docs/source/dnpHydration.rst
@@ -33,7 +33,7 @@ To use the dnpHydration module first create a dictionary with the necessary inpu
               'spin_C': 100, # spin concentration in micromolar
               'field': 350, # magnetic field in mT
               'smax_model': 'tethered', # choice of smax model
-              't1_interp_method': 'second_order' # choice of interpolation method
+              'interpolate_method': 'second_order' # choice of interpolation method
               }
     
 

--- a/unittests/test_dnpImport.py
+++ b/unittests/test_dnpImport.py
@@ -109,12 +109,12 @@ class specman_import_tester(unittest.TestCase):
 
     def test_import_specman_2D(self):
         data = wrapper.load(self.test_data_2D, data_type="specman")
-        self.assertEqual(data.dims, ["t", "x"])
+        self.assertEqual(data.dims, ["t2", "t1"])
         self.assertEqual(data.values.shape, (1500, 80))
 
     def test_import_specman_4D(self):
         data = wrapper.load(self.test_data_4D, data_type="specman")
-        self.assertEqual(data.dims, ["t", "x", "y", "z"])
+        self.assertEqual(data.dims, ["t2", "t1", "t0", "t"])
         self.assertEqual(data.values.shape, (1500, 40, 5, 3))
 
 

--- a/unittests/test_dnpImport.py
+++ b/unittests/test_dnpImport.py
@@ -128,10 +128,10 @@ class bes3t_import_tester(unittest.TestCase):
 
     def test_import_bes3t_HYSCORE(self):
         data = wrapper.load(self.test_data_HYSCORE, data_type="xepr")
-        self.assertEqual(data.dims, ["t2", "ns"])
+        self.assertEqual(data.dims, ["t2", "t1"])
         self.assertEqual(data.values.shape, (175, 175))
         self.assertEqual(max(data.coords["t2"]), 3520.0)
-        self.assertEqual(max(data.coords["ns"]), 3480.0)
+        self.assertEqual(max(data.coords["t1"]), 3520.0)
 
     def test_import_bes3t_DEER(self):
         data = wrapper.load(self.test_data_DEER, data_type="xepr")
@@ -141,19 +141,19 @@ class bes3t_import_tester(unittest.TestCase):
 
     def test_import_bes3t_ESE(self):
         data = wrapper.load(self.test_data_ESE, data_type="xepr")
-        self.assertEqual(data.dims, ["t2", "index"])
+        self.assertEqual(data.dims, ["t2", "t1"])
         self.assertEqual(data.values.shape, (512, 50))
         self.assertEqual(data.attrs["frequency"], 9.296)
 
     def test_import_bes3t_1D(self):
         data = wrapper.load(self.test_data_1D, data_type="xenon")
-        self.assertEqual(data.dims, ["B0"])
+        self.assertEqual(data.dims, ["t2"])
         self.assertEqual(data.values.shape, (2250,))
         self.assertEqual(data.attrs["frequency"], 9.804448)
 
     def test_import_bes3t_2D(self):
         data = wrapper.load(self.test_data_2D, data_type="xenon")
-        self.assertEqual(data.dims, ["B0", "s"])
+        self.assertEqual(data.dims, ["t2", "t1"])
         self.assertEqual(data.values.shape, (1600, 100))
         self.assertEqual(data.attrs["frequency"], 9.627213)
 
@@ -172,13 +172,13 @@ class winepr_import_tester(unittest.TestCase):
 
     def test_import_winepr_1D(self):
         data = wrapper.load(self.test_data_1D, data_type="winepr")
-        self.assertEqual(data.dims, ["B0"])
+        self.assertEqual(data.dims, ["t2"])
         self.assertEqual(data.values.shape, (512,))
         self.assertEqual(data.attrs["temperature"], 294.2)
 
     def test_import_winepr_2D(self):
         data = wrapper.load(self.test_data_2D, data_type="winepr")
-        self.assertEqual(data.dims, ["B0", "dB"])
+        self.assertEqual(data.dims, ["t2", "t1"])
         self.assertEqual(data.values.shape, (1024, 15))
         self.assertEqual(data.attrs["frequency"], 9.79)
 

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -206,10 +206,10 @@ class dnpNMR_tester(unittest.TestCase):
         )
 
         self.assertAlmostEqual(
-            self.ws_off["enhancements"].values[0], -0.005967949713665632, places=6
+            self.ws_off["enhancements"].values[0], -0.8783961394424274, places=6
         )
         self.assertAlmostEqual(
-            self.ws_off["enhancements"].values[-1], 0.004154668257187268, places=6
+            self.ws_off["enhancements"].values[-1], 0.9658179866930302, places=6
         )
 
 

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -120,10 +120,10 @@ class dnpNMR_tester(unittest.TestCase):
             force_positive=False,
         )
         self.assertAlmostEqual(
-            max(self.ws["proc"].values[:, 3].real), 242.36299886442168, places=4
+            max(self.ws["proc"].values[:, 3].real), 227.24572247945258, places=4
         )
         self.assertAlmostEqual(
-            min(self.ws["proc"].values[:, 3].real), -65.59778997862813, places=4
+            min(self.ws["proc"].values[:, 3].real), -157.25762551416526, places=4
         )
         phs0 = self.ws["proc"].attrs["phase0"]
         phs1 = self.ws["proc"].attrs["phase1"]
@@ -139,10 +139,10 @@ class dnpNMR_tester(unittest.TestCase):
             force_positive=True,
         )
         self.assertAlmostEqual(
-            max(self.ws["proc"].values[:, 7].real), 398.66277628048533, places=4
+            max(self.ws["proc"].values[:, 7].real), 411.71339056159314, places=4
         )
         self.assertAlmostEqual(
-            min(self.ws["proc"].values[:, 7].real), -47.32339420356964, places=4
+            min(self.ws["proc"].values[:, 7].real), 0.13285193948862864, places=4
         )
         self.ws.copy("temp", "proc")
 
@@ -155,10 +155,10 @@ class dnpNMR_tester(unittest.TestCase):
             phase=phs1 * (45 * np.pi / 180),
         )
         self.assertAlmostEqual(
-            max(self.ws["proc"].values[:, 3].real), 239.3422920589204, places=4
+            max(self.ws["proc"].values[:, 3].real), 227.24572247945258, places=4
         )
         self.assertAlmostEqual(
-            min(self.ws["proc"].values[:, 3].real), -64.37971134351001, places=4
+            min(self.ws["proc"].values[:, 3].real), -157.25762551416526, places=4
         )
         self.ws.copy("temp", "proc")
 

--- a/unittests/test_dnpNMR.py
+++ b/unittests/test_dnpNMR.py
@@ -181,22 +181,13 @@ class dnpNMR_tester(unittest.TestCase):
         nmr.window(self.ws, linewidth=15)
         nmr.fourier_transform(self.ws, zero_fill_factor=2)
         nmr.autophase(self.ws, method="arctan")
-
         ws = copy.deepcopy(self.ws)
-
-        nmr.calculate_enhancement(
-            self.ws,
-            off_spectrum=1,
-            on_spectra="all",
-            integrate_center=0,
-            integrate_width="full",
-            method="integrate",
-            dim="f2",
-        )
+        dnp.dnpTools.integrate(self.ws, integrate_center=0, integrate_width="full")
+        nmr.calculate_enhancement(self.ws)
 
         self.assertAlmostEqual(self.ws["enhancements"].values[0], 1.0, places=6)
         self.assertAlmostEqual(
-            self.ws["enhancements"].values[-1], -1.3615844024369856, places=6
+            self.ws["enhancements"].values[-1], -1.3474199443567987, places=6
         )
 
         nmr.remove_offset(self.ws_off)
@@ -207,7 +198,7 @@ class dnpNMR_tester(unittest.TestCase):
         nmr.calculate_enhancement(
             self.ws_off,
             off_spectrum=self.ws_off["proc"],
-            on_spectra=self.ws["proc"],
+            on_spectra=ws["proc"],
             integrate_center="max",
             integrate_width="full",
             method="amplitude",
@@ -219,14 +210,6 @@ class dnpNMR_tester(unittest.TestCase):
         )
         self.assertAlmostEqual(
             self.ws_off["enhancements"].values[-1], 0.004154668257187268, places=6
-        )
-
-        dnp.dnpTools.integrate(ws, integrate_center=0, integrate_width="full")
-        nmr.calculate_enhancement(ws, off_spectrum=1)
-
-        self.assertAlmostEqual(ws["enhancements"].values[0], 1.0, places=6)
-        self.assertAlmostEqual(
-            ws["enhancements"].values[-1], -1.3615844024369856, places=6
         )
 
 

--- a/unittests/test_dnpTools.py
+++ b/unittests/test_dnpTools.py
@@ -118,10 +118,10 @@ class dnpTools_tester(unittest.TestCase):
         )
         self.assertEqual((3, 8), np.shape(ws2["integrals"].values))
         self.assertAlmostEqual(
-            max(ws3["integrals"].values.real[1]), 6170.447249940133, places=4
+            max(ws3["integrals"].values.real[1][1]), 6170.447249940133, places=4
         )
         self.assertAlmostEqual(
-            min(ws3["integrals"].values.real[1]), -7188.897892203664, places=4
+            min(ws3["integrals"].values.real[1][1]), -7188.897892203664, places=4
         )
 
     def test_mr_properties(self):


### PR DESCRIPTION
- [x] closes issues #146, #159 , #164 
- [x] tests added / passed `pytest .`
- [x] passes `black .`
- [x] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] many improvements in 3D data handling, including support for 3D topspin and 3D Bruker BES3T EPR data
- [x] reference range added to autophase 
- [x] code cleanup, fixes in docs
- [x]  bug fixes in autophase, integrate, and calculate_enhancement
- [x] removed indirect_dim arguments   
- [x] centralize return_data function and remove from modules
- [x] complete the revert from using zero_fill function in transforms
- [x] fix zero_fill standalone function 
- [x] added mode to baseline to choose subtract or divide