### PR TITLE
Improvements in hydration and added example

### DIFF
--- a/dnplab/analysis/hydration.py
+++ b/dnplab/analysis/hydration.py
@@ -222,7 +222,7 @@ def calculate_tcorr(coupling_factor=0.27, omega_e=0.0614, omega_H=9.3231e-05):
         raise ValueError("Could not find tcorr")
 
     tcorr = result.root
-    return tcorr * 1e-12
+    return tcorr
 
 
 def calculate_uncorrected_Ep(

--- a/dnplab/analysis/hydration.py
+++ b/dnplab/analysis/hydration.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy import interpolate
 from scipy import optimize
 
 
@@ -340,7 +339,7 @@ def calculate_uncorrected_xi(
     return uncorrected_xi, p_12_unc
 
 
-def odnp(data={}, constants={}):
+def hydration(data={}, constants={}):
     """Function for performing ODNP calculations
 
     Args:

--- a/dnplab/analysis/hydration.py
+++ b/dnplab/analysis/hydration.py
@@ -222,7 +222,7 @@ def calculate_tcorr(coupling_factor=0.27, omega_e=0.0614, omega_H=9.3231e-05):
         raise ValueError("Could not find tcorr")
 
     tcorr = result.root
-    return tcorr
+    return tcorr * 1e-12
 
 
 def calculate_uncorrected_Ep(
@@ -500,7 +500,6 @@ def hydration(data={}, constants={}):
     # optimizes the value of tcorr in the calculation of coupling_factor, the correct tcorr
     # is the one for which the calculation of coupling_factor from the spectral density
     # functions matches the coupling_factor found experimentally. tcorr unit is ps
-    tcorr *= 1e-12
 
     Dlocal = (odnp_constants["tcorr_bulk"] / tcorr) * (
         odnp_constants["D_H2O"] + odnp_constants["D_SL"]

--- a/dnplab/analysis/hydration.py
+++ b/dnplab/analysis/hydration.py
@@ -363,7 +363,7 @@ def hydration(data={}, constants={}):
         "ksigma_bulk": 95.4,
         "krho_bulk": 353.4,
         "klow_bulk": 366,
-        "tcorr_bulk": 54,
+        "tcorr_bulk": 54e-12,
         "D_H2O": 2.3e-9,
         "D_SL": 4.1e-10,
         "delta_T1_water": False,
@@ -396,12 +396,12 @@ def hydration(data={}, constants={}):
             "'smax_model' must be 'tethered', 'free', or a float between 0 and 1"
         )
 
-    omega_e = (1.76085963023e-1) * (data["magnetic_field"] / 1000)
+    omega_e = 1.76085963023e-1 * data["magnetic_field"]
     # gamma_e in 1/ps for the tcorr unit, then correct by magnetic_field in T.
     # gamma_e is from NIST. The magnetic_field cancels in the following omega_ratio but you
     # need these individually for the spectral density functions later.
 
-    omega_H = (2.6752218744e-4) * (data["magnetic_field"] / 1000)
+    omega_H = 2.6752218744e-4 * data["magnetic_field"]
     # gamma_H in 1/ps for the tcorr unit, then correct by magnetic_field in T.
     # gamma_H is from NIST. The magnetic_field cancels in the following omega_ratio but you
     # need these individually for the spectral density functions later.
@@ -452,6 +452,7 @@ def hydration(data={}, constants={}):
     # optimizes the value of tcorr in the calculation of coupling_factor, the correct tcorr
     # is the one for which the calculation of coupling_factor from the spectral density
     # functions matches the coupling_factor found experimentally. tcorr unit is ps
+    tcorr *= 1e-12
 
     Dlocal = (odnp_constants["tcorr_bulk"] / tcorr) * (
         odnp_constants["D_H2O"] + odnp_constants["D_SL"]

--- a/dnplab/analysis/hydration.py
+++ b/dnplab/analysis/hydration.py
@@ -177,12 +177,12 @@ def calculate_xi(tcorr=54, omega_e=0.0614, omega_H=9.3231e-05):
 
     # (Eq. 2)
     Jdiff = (1 + (zdiff / 4)) / (
-        1 + zdiff + ((4 * (zdiff ** 2)) / 9) + ((zdiff ** 3) / 9)
+        1 + zdiff + ((4 * (zdiff**2)) / 9) + ((zdiff**3) / 9)
     )
 
-    Jsum = (1 + (zsum / 4)) / (1 + zsum + ((4 * (zsum ** 2)) / 9) + ((zsum ** 3) / 9))
+    Jsum = (1 + (zsum / 4)) / (1 + zsum + ((4 * (zsum**2)) / 9) + ((zsum**3) / 9))
 
-    JH = (1 + (zH / 4)) / (1 + zH + ((4 * (zH ** 2)) / 9) + ((zH ** 3) / 9))
+    JH = (1 + (zH / 4)) / (1 + zH + ((4 * (zH**2)) / 9) + ((zH**3) / 9))
 
     # (Eq. 23) calculation of coupling_factor from the spectral density functions
     xi = ((6 * np.real(Jdiff)) - np.real(Jsum)) / (

--- a/docs/source/_static/linkList.rst
+++ b/docs/source/_static/linkList.rst
@@ -76,3 +76,8 @@
 
    <a href="https://han.chem.ucsb.edu/" target="_blank"> Han Lab</a>
 
+
+.. |tcaseyLink| raw:: html
+
+   <a href="https://www.linkedin.com/in/thcasey3/" target="_blank"> LinkedIn</a>
+

--- a/docs/source/people.rst
+++ b/docs/source/people.rst
@@ -11,7 +11,7 @@ Currently active authors and contributors:
 
 * Timothy Keller (|B12TLink|)
 * Thorsten Maly (|B12TLink|, |thmalyTwitter|)
-* Tom Casey
+* Thomas Casey (|tcaseyLink|)
 * John Franck (|FranckLabLink|)
 * Yen-Chun Huang (|B12TLink|)
 * Thomas Webber (|HanLabLink|)

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -9,8 +9,8 @@ Analyze ODNP Data
 This example demonstrates how to use the hydration module to analyze ODNP data.
 """
 # %%
-# Import the hydration module
-# ---------------------------
+# Imports
+# -------
 import dnplab
 import numpy as np
 import matplotlib.pyplot as plt
@@ -49,7 +49,7 @@ standard_constants = {
 # %%
 # Constants used in 2nd order T1 interpolation
 # --------------------------------------------
-# It is typically unnecessary to adjust these constants. Look at the SI of https://doi.org/10.1021/jacs.1c11342 for explanation.
+# It is typically unnecessary to adjust these constants. Explanation can be found in the SI of https://doi.org/10.1021/jacs.1c11342
 
 interpolation_constants = {
     "delta_T1_water": 1,  # change in water proton T1 due to microwaves
@@ -64,7 +64,7 @@ constants = {**standard_constants, **interpolation_constants}
 # %%
 # Calculate results
 # -----------------
-# If any adjustments are made to the constants, pass both dictionaries to hydration.odnp to return a dictionary of results,
+# If any adjustments are made to the constants, pass both dictionaries to dnplab.hydration to return a dictionary of results,
 
 results = dnplab.hydration(data, constants)
 

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -16,14 +16,89 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # %%
+# Example Data
+# ------------
+enhancements = np.array(
+    [
+        0.57794113752189,
+        -0.4688718613022250,
+        -0.5464528159680670,
+        -1.0725090541762200,
+        -1.4141203961920700,
+        -1.695789643686440,
+        -1.771840068080760,
+        -1.8420812985152700,
+        -1.97571340381877,
+        -2.091405209753480,
+        -2.1860546327712800,
+        -2.280712535872610,
+        -2.4709892163826400,
+        -2.5184316153191200,
+        -2.556110148443770,
+        -2.576413132701720,
+        -2.675593912859120,
+        -2.8153300703866400,
+        -2.897475156648710,
+        -3.0042154567120800,
+        -3.087886507216510,
+    ]
+)
+
+enhancement_powers = np.array(
+    [
+        0.0006454923080882520,
+        0.004277023425898170,
+        0.004719543572446050,
+        0.00909714298712173,
+        0.01344187403986090,
+        0.01896059941058610,
+        0.02101937603827090,
+        0.022335737104727900,
+        0.026029715703921800,
+        0.02917012237740640,
+        0.0338523245243911,
+        0.03820738749745440,
+        0.04733370907740660,
+        0.05269608016472140,
+        0.053790874615060400,
+        0.05697639350179900,
+        0.06435487925718170,
+        0.07909179437004270,
+        0.08958910066880800,
+        0.1051813598911370,
+        0.11617812912435900,
+    ]
+)
+
+T1s = np.array(
+    [
+        2.020153734009,
+        2.276836030132750,
+        2.3708172489377400,
+        2.4428968088189100,
+        2.5709096032675700,
+    ]
+)
+
+T1_powers = np.array(
+    [
+        0.000589495934876689,
+        0.024242327290569100,
+        0.054429505156431400,
+        0.0862844940360515,
+        0.11617812912435900,
+    ]
+)
+
+# %%
 # Setup your data dictionary
 # --------------------------
 
 data = {
-    "E_array": np.array(),  # numpy array of signal enhancements
-    "E_powers": np.array(),  # numpy array of microwave power levels used to collect enhancements
-    "T1_array": np.array(),  # numpy array of T1 measurements in seconds
-    "T1_powers": np.array(),  # numpy array of microwave power levels used to collect T1s
+    "E_array": enhancements,  # numpy array of signal enhancements
+    "E_powers": enhancement_powers,  # numpy array of microwave power levels used to collect enhancements
+    "T1_array": T1s,  # numpy array of T1 measurements in seconds
+    "T1_powers": T1_powers,  # numpy array of microwave power levels used to collect T1s
     "T10": 2.0,  # T1 measured with microwave power = 0
     "T100": 2.5,  # T1 measured for sample without unpaired spin and microwave power = 0
     "spin_C": 100e-6,  # spin concentration in M
@@ -33,8 +108,8 @@ data = {
 }
 
 # %%
-# Standard constants
-# ------------------
+# Optional - adjust constants
+# ---------------------------
 # In general the constants used in the calculations are kept the same as those found in literature. You may update these values if you wish but this is rarely necessary and will make direct comparisons with most existing literature invalid.
 
 standard_constants = {
@@ -47,9 +122,7 @@ standard_constants = {
 }
 
 # %%
-# Constants used in 2nd order T1 interpolation
-# --------------------------------------------
-# It is typically unnecessary to adjust these constants. Explanation can be found in the SI of https://doi.org/10.1021/jacs.1c11342
+# It is typically unnecessary to adjust the constants used in 2nd order interpolation but they are adjustable. Explanation can be found in the SI of https://doi.org/10.1021/jacs.1c11342
 
 interpolation_constants = {
     "delta_T1_water": 1,  # change in water proton T1 due to microwaves
@@ -58,7 +131,8 @@ interpolation_constants = {
 }
 
 # %%
-# combine the dictionaries of standard and additional constants into one,
+# Combine any dictionaries of constants into one with something like,
+
 constants = {**standard_constants, **interpolation_constants}
 
 # %%
@@ -84,5 +158,6 @@ print(results.keys())
 plt.figure()
 plt.plot(data["E_powers"], results["ksigma_array"], "o", label="Data")
 plt.plot(data["E_powers"], results["ksigma_fit"], label="Fit")
+plt.grid()
 plt.legend()
 plt.show()

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -9,6 +9,12 @@ Analyze ODNP Data
 This example demonstrates how to use the hydration module to analyze ODNP data.
 """
 # %%
+# References
+# ----------
+# It is helpful to be familiar with at least http://dx.doi.org/10.1016/j.pnmrs.2013.06.001 and
+# https://doi.org/10.1016/bs.mie.2018.09.024 before setting the parameters and performing calculations.
+
+# %%
 # Imports
 # -------
 import dnplab
@@ -91,18 +97,18 @@ T1_powers = np.array(
 )
 
 # %%
-# Setup your data dictionary
-# --------------------------
+# Set up your data dictionary
+# ---------------------------
 
 data = {
-    "E_array": enhancements,  # numpy array of signal enhancements
+    "E_array": enhancements,  # numpy array of signal enhancements (unitless)
     "E_powers": enhancement_powers,  # numpy array of microwave power levels used to collect enhancements
-    "T1_array": T1s,  # numpy array of T1 measurements in seconds
+    "T1_array": T1s,  # numpy array of T1 measurements (s)
     "T1_powers": T1_powers,  # numpy array of microwave power levels used to collect T1s
-    "T10": 2.0,  # T1 measured with microwave power = 0
-    "T100": 2.5,  # T1 measured for sample without unpaired spin and microwave power = 0
-    "spin_C": 100e-6,  # spin concentration in M
-    "magnetic_field": 0.35,  # magnetic field in T
+    "T10": 2.0,  # T1 measured with microwave power = 0 (s)
+    "T100": 2.5,  # T1 measured for sample without unpaired spin and microwave power = 0 (s)
+    "spin_C": 100e-6,  # spin concentration (M)
+    "magnetic_field": 0.35,  # magnetic field (T)
     "smax_model": "tethered",  # choice of smax model or direct input of smax value
     "interpolate_method": "second_order",  # choice of interpolation method
 }
@@ -110,54 +116,83 @@ data = {
 # %%
 # Optional - adjust constants
 # ---------------------------
-# In general the constants used in the calculations are kept the same as those found in literature. You may update these values if you wish but this is rarely necessary and will make direct comparisons with most existing literature invalid.
+# In general the constants used in the calculations are kept the same as those found in literature.
+# You may update these values if you wish but this is rarely necessary and will make direct comparisons with most
+# existing literature invalid.
 
 standard_constants = {
-    "ksigma_bulk": 95.4,  # bulk ksigma value
-    "krho_bulk": 353.4,  # bulk krho value
-    "klow_bulk": 366,  # bulk klow value
-    "tcorr_bulk": 54e-12,  # bulk tcorr value in seconds
-    "D_H2O": 2.3e-9,  # bulk water diffusivity
-    "D_SL": 4.1e-10,  # diffusivity of spin probe in bulk water
+    "ksigma_bulk": 95.4,  # bulk ksigma value (s^-1 * M^-1)
+    "krho_bulk": 353.4,  # bulk krho value (s^-1 * M^-1)
+    "klow_bulk": 366,  # bulk klow value (s^-1 * M^-1)
+    "tcorr_bulk": 54e-12,  # bulk tcorr value (s)
+    "D_H2O": 2.3e-9,  # bulk water diffusivity (m^2 / s)
+    "D_SL": 4.1e-10,  # diffusivity of spin probe in bulk water (m^2 / s)
 }
 
 # %%
-# It is typically unnecessary to adjust the constants used in 2nd order interpolation but they are adjustable. Explanation can be found in the SI of https://doi.org/10.1021/jacs.1c11342
+# It is typically unnecessary to adjust the constants used in 2nd order interpolation, although they are adjustable
+# if necessary. Explanation can be found in the SI of https://doi.org/10.1021/jacs.1c11342
 
 interpolation_constants = {
-    "delta_T1_water": 1,  # change in water proton T1 due to microwaves
-    "T1_water": 2.5,  # T1 of bulk water protons
-    "macro_C": 100e-6,  # concentration of macromolecule in M
+    "delta_T1_water": 1,  # change in water proton T1 due to microwaves (s)
+    "T1_water": 2.5,  # T1 of bulk water protons (s)
+    "macro_C": 100e-6,  # concentration (M)
 }
 
 # %%
-# Combine any dictionaries of constants into one with something like,
+# Combine any dictionaries of constants into one dictionary with something like,
 
 constants = {**standard_constants, **interpolation_constants}
 
 # %%
 # Calculate results
 # -----------------
-# If any adjustments are made to the constants, pass both dictionaries to dnplab.hydration to return a dictionary of results,
+# If any adjustments are made to the constants, pass both dictionaries to ``dnplab.hydration``,
 
 results = dnplab.hydration(data, constants)
 
 # %%
-# If no adjustments are made to the constants you can skip the creation of the constants dictionary and pass just the data dictionary alone,
+# If no adjustments are made to the constants you can skip the creation of the constants dictionary and pass just the
+# data dictionary alone,
 
 results = dnplab.hydration(data)
 
 # %%
-# Print a list of the calculated arrays and values,
+# The contents of the calculated results are as follows,
 
-print(results.keys())
+results_contents = {
+    "uncorrected_Ep": np.array,  # fit to enhancement profile using the "uncorrected model" (unitless)
+    "uncorrected_xi": float,  # coupling factor calculated from the "uncorrected" fit (unitless)
+    "interpolated_T1": np.array,  # array of T1s obtained from interpolation (s)
+    "ksigma_array": np.array,  # array of ksigma calculated using the enhancement and T1 data (s^-1 * M^-1)
+    "ksigma_fit": np.array,  # fit to ksigma_array (s^-1 * M^-1)
+    "ksigma": float,  # (s^-1 * M^-1)
+    "ksigma_stdd": float,  # standard deviation in ksigma (s^-1 * M^-1)
+    "ksigma_bulk_ratio": float,  # ratio ksigma / ksigma_bulk (unitless)
+    "krho": float,  # (s^-1 * M^-1)
+    "krho_bulk_ratio": float,  # ratio krho / krho_bulk (unitless)
+    "klow": float,  # (s^-1 * M^-1)
+    "klow_bulk_ratio": float,  # ratio klow / klow_bulk (unitless)
+    "coupling_factor": float,  # coupling factor from spectral density function (unitless)
+    "tcorr": float,  # translational correlation time (s)
+    "tcorr_bulk_ratio": float,  # ratio tcorr / tcorr_bulk (unitless)
+    "Dlocal": float,  # local diffusivity (m^2 / s)
+}
+
 
 # %%
-# Plot the k_sigma array and fit, for example,
+# Plot the ``'ksigma_array'`` and ``'ksigma_fit'``, for example.
 
 plt.figure()
 plt.plot(data["E_powers"], results["ksigma_array"], "o", label="Data")
 plt.plot(data["E_powers"], results["ksigma_fit"], label="Fit")
 plt.grid()
+plt.xlabel("microwave power")
+plt.ylabel("$\kappa_\sigma$")
+plt.title("$\kappa_\sigma$ vs. microwave power")
 plt.legend()
 plt.show()
+
+# %%
+# Note: for a MATLAB app that includes an interactive parameter tuning tool - where the effects of parameters on the
+# calculations can be visualized - please visit: https://www.mathworks.com/matlabcentral/fileexchange/73293-xodnp

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -174,7 +174,7 @@ results_contents = {
     "klow": float,  # (s^-1 * M^-1)
     "klow_bulk_ratio": float,  # ratio klow / klow_bulk (unitless)
     "coupling_factor": float,  # coupling factor from spectral density function (unitless)
-    "tcorr": float,  # translational correlation time (s)
+    "tcorr": float,  # translational diffusion correlation time (s)
     "tcorr_bulk_ratio": float,  # ratio tcorr / tcorr_bulk (unitless)
     "Dlocal": float,  # local diffusivity (m^2 / s)
 }

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -1,0 +1,88 @@
+# %%
+"""
+.. _plot_03_analyze_odnp_data:
+
+=================
+Analyze ODNP Data
+=================
+
+This example demonstrates how to use the hydration module to analyze ODNP data.
+"""
+# %%
+# Import the hydration module
+# ---------------------------
+import dnplab
+import numpy
+import matplotlib.pyplot as plt
+
+# %%
+# Setup your data dictionary
+# --------------------------
+
+data = {
+    "E_array": Enhancements,  # numpy array of signal enhancements
+    "E_powers": Enhancement_powers,  # numpy array of microwave power levels used to collect enhancements
+    "T1_array": T1s,  # numpy array of T1 measurements in seconds
+    "T1_powers": T1_powers,  # numpy array of microwave power levels used to collect T1s
+    "T10": 2.0,  # T1 measured with microwave power = 0
+    "T100": 2.5,  # T1 measured for sample without unpaired spin and microwave power = 0
+    "spin_C": 100,  # spin concentration in M
+    "magnetic_field": 350,  # magnetic field in mT
+    "smax_model": "tethered",  # choice of smax model or direct input of smax value
+    "interpolate_method": "second_order",  # choice of interpolation method
+}
+
+# %%
+# Standard constants
+# ------------------
+# In general the constants used in the calculations are kept the same as those found in literature. You may update these values if you wish but this is rarely necessary and will make direct comparisons with most existing literature invalid.
+
+standard_constants = {
+    "ksigma_bulk": 95.4,  # bulk ksigma value
+    "krho_bulk": 353.4,  # bulk krho value
+    "klow_bulk": 366,  # bulk klow value
+    "tcorr_bulk": 54,  # bulk tcorr value
+    "D_H2O": 2.3e-9,  # bulk water diffusivity
+    "D_SL": 4.1e-10,  # diffusivity of spin probe in bulk water
+}
+
+# %%
+# Constants used in 2nd order T1 interpolation
+# --------------------------------------------
+# It is typically unnecessary to adjust these constants. Look at the SI of https://doi.org/10.1021/jacs.1c11342 for explanation.
+
+interpolation_constants = {
+    "delta_T1_water": 1,  # change in water proton T1 due to microwaves
+    "T1_water": 2.5,  # T1 of bulk water protons
+    "macro_C": 1e-3,  # concentration of macromolecule in M
+}
+
+# %%
+# combine the dictionaries of standard and additional constants into one,
+constants = {**standard_constants, **interpolation_constants}
+
+# %%
+# Calculate results
+# -----------------
+# If any adjustments are made to the constants, pass both dictionaries to hydration.odnp to return a dictionary of results,
+
+results = dnplab.analysis.hydration.odnp(data, constants)
+
+# %%
+# If no adjustments are made to the constants you can skip the creation of the constants dictionary and pass just the data dictionary alone,
+
+results = dnplab.analysis.hydration.odnp(data)
+
+# %%
+# Print a list of the calculated arrays and values,
+
+print(results.keys())
+
+# %%
+# Plot the k_sigma array and fit, for example,
+
+plt.figure()
+plt.plot(data["E_powers"], results["ksigma_array"], "o", label="Data")
+plt.plot(data["E_powers"], results["ksigma_fit"], label="Fit")
+plt.legend()
+plt.show()

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -27,7 +27,7 @@ data = {
     "T10": 2.0,  # T1 measured with microwave power = 0
     "T100": 2.5,  # T1 measured for sample without unpaired spin and microwave power = 0
     "spin_C": 100e-6,  # spin concentration in M
-    "magnetic_field": 350,  # magnetic field in mT
+    "magnetic_field": 0.35,  # magnetic field in T
     "smax_model": "tethered",  # choice of smax model or direct input of smax value
     "interpolate_method": "second_order",  # choice of interpolation method
 }
@@ -41,7 +41,7 @@ standard_constants = {
     "ksigma_bulk": 95.4,  # bulk ksigma value
     "krho_bulk": 353.4,  # bulk krho value
     "klow_bulk": 366,  # bulk klow value
-    "tcorr_bulk": 54,  # bulk tcorr value
+    "tcorr_bulk": 54e-12,  # bulk tcorr value in seconds
     "D_H2O": 2.3e-9,  # bulk water diffusivity
     "D_SL": 4.1e-10,  # diffusivity of spin probe in bulk water
 }

--- a/examples/02_Analysis/plot_03_analyze_odnp_data.py
+++ b/examples/02_Analysis/plot_03_analyze_odnp_data.py
@@ -12,7 +12,7 @@ This example demonstrates how to use the hydration module to analyze ODNP data.
 # Import the hydration module
 # ---------------------------
 import dnplab
-import numpy
+import numpy as np
 import matplotlib.pyplot as plt
 
 # %%
@@ -20,13 +20,13 @@ import matplotlib.pyplot as plt
 # --------------------------
 
 data = {
-    "E_array": Enhancements,  # numpy array of signal enhancements
-    "E_powers": Enhancement_powers,  # numpy array of microwave power levels used to collect enhancements
-    "T1_array": T1s,  # numpy array of T1 measurements in seconds
-    "T1_powers": T1_powers,  # numpy array of microwave power levels used to collect T1s
+    "E_array": np.array(),  # numpy array of signal enhancements
+    "E_powers": np.array(),  # numpy array of microwave power levels used to collect enhancements
+    "T1_array": np.array(),  # numpy array of T1 measurements in seconds
+    "T1_powers": np.array(),  # numpy array of microwave power levels used to collect T1s
     "T10": 2.0,  # T1 measured with microwave power = 0
     "T100": 2.5,  # T1 measured for sample without unpaired spin and microwave power = 0
-    "spin_C": 100,  # spin concentration in M
+    "spin_C": 100e-6,  # spin concentration in M
     "magnetic_field": 350,  # magnetic field in mT
     "smax_model": "tethered",  # choice of smax model or direct input of smax value
     "interpolate_method": "second_order",  # choice of interpolation method
@@ -54,7 +54,7 @@ standard_constants = {
 interpolation_constants = {
     "delta_T1_water": 1,  # change in water proton T1 due to microwaves
     "T1_water": 2.5,  # T1 of bulk water protons
-    "macro_C": 1e-3,  # concentration of macromolecule in M
+    "macro_C": 100e-6,  # concentration of macromolecule in M
 }
 
 # %%
@@ -66,12 +66,12 @@ constants = {**standard_constants, **interpolation_constants}
 # -----------------
 # If any adjustments are made to the constants, pass both dictionaries to hydration.odnp to return a dictionary of results,
 
-results = dnplab.analysis.hydration.odnp(data, constants)
+results = dnplab.hydration(data, constants)
 
 # %%
 # If no adjustments are made to the constants you can skip the creation of the constants dictionary and pass just the data dictionary alone,
 
-results = dnplab.analysis.hydration.odnp(data)
+results = dnplab.hydration(data)
 
 # %%
 # Print a list of the calculated arrays and values,

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -82,7 +82,7 @@ class TestHydration(unittest.TestCase):
             "E_powers": TESTSET["E_power"],
             "T1_array": TESTSET["T1"],
             "T1_powers": TESTSET["T1_power"],
-            "field": 348.5,
+            "magnetic_field": 348.5,
             "spin_C": 125e-6,
             "T10": 2.0,
             "T100": 2.5,

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -83,7 +83,7 @@ class TestHydration(unittest.TestCase):
             "T1_array": TESTSET["T1"],
             "T1_powers": TESTSET["T1_power"],
             "field": 348.5,
-            "spin_C": 125,
+            "spin_C": 125e-6,
             "T10": 2.0,
             "T100": 2.5,
             "smax_model": "tethered",
@@ -149,7 +149,7 @@ class TestHydration(unittest.TestCase):
 
     def test_hydration_inplace(self):
 
-        self.ws["hydration_inputs"]["spin_C"] = 100
+        self.ws["hydration_inputs"]["spin_C"] = 100e-6
         self.ws["hydration_inputs"]["smax_model"] = "free"
         self.ws["hydration_inputs"]["interpolate_method"] = "linear"
         self.ws["hydration_constants"]["D_SL"] = 4.1e-9

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -102,13 +102,9 @@ class TestHydration(unittest.TestCase):
             "macro_C": False,
         }
 
-        self.ws = {}
-        self.ws["hydration_inputs"] = self.data
-        self.ws["hydration_constants"] = self.constants
+    def test_hydration(self):
 
-    def test_hydration_return_dict(self):
-
-        result = dnp.hydration(self.ws)
+        result = dnp.hydration(self.data, self.constants)
 
         self.assertEqual(len(self.data["E_powers"]), 21)
         self.assertEqual(len(self.data["E_array"]), 21)
@@ -142,75 +138,3 @@ class TestHydration(unittest.TestCase):
         self.assertAlmostEqual(result["klow"], 1286.2512443126634, places=6)
         self.assertAlmostEqual(result["tcorr"], 485.8952027395348, places=6)
         self.assertAlmostEqual(result["Dlocal"], 3.01176054373284e-10, places=6)
-
-        self.assertTrue(
-            [x in self.ws["hydration_results"].keys() for x in result.keys()]
-        )
-
-    def test_hydration_inplace(self):
-
-        self.ws["hydration_inputs"]["spin_C"] = 100e-6
-        self.ws["hydration_inputs"]["smax_model"] = "free"
-        self.ws["hydration_inputs"]["interpolate_method"] = "linear"
-        self.ws["hydration_constants"]["D_SL"] = 4.1e-9
-
-        dnp.hydration(self.ws)
-
-        self.assertEqual(len(self.ws["hydration_results"]["interpolated_T1"]), 21)
-        self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["interpolated_T1"]),
-            2.0978389591800344,
-            places=6,
-        )
-        self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["interpolated_T1"]),
-            2.5855460713039324,
-            places=6,
-        )
-        self.assertEqual(len(self.ws["hydration_results"]["ksigma_array"]), 21)
-        self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["ksigma_array"]),
-            3.0565812706454305,
-            places=6,
-        )
-        self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["ksigma_array"]),
-            24.020476541485717,
-            places=6,
-        )
-        self.assertEqual(len(self.ws["hydration_results"]["ksigma_fit"]), 21)
-        self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["ksigma_fit"]),
-            2.3390612006821225,
-            places=6,
-        )
-        self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["ksigma_fit"]),
-            24.280175919600392,
-            places=6,
-        )
-        self.assertEqual(len(self.ws["hydration_results"]["uncorrected_Ep"]), 21)
-        self.assertAlmostEqual(
-            min(self.ws["hydration_results"]["uncorrected_Ep"]),
-            -2.9084738857665413,
-            places=6,
-        )
-        self.assertAlmostEqual(
-            max(self.ws["hydration_results"]["uncorrected_Ep"]),
-            0.7434984946695101,
-            places=6,
-        )
-
-        self.assertAlmostEqual(
-            self.ws["hydration_results"]["ksigma"], 73.98621213840886, places=6
-        )
-        self.assertAlmostEqual(
-            self.ws["hydration_results"]["klow"], 1494.0321716770457, places=6
-        )
-        self.assertAlmostEqual(
-            self.ws["hydration_results"]["tcorr"], 230.5905102559904, places=6
-        )
-
-        self.assertAlmostEqual(
-            self.ws["hydration_results"]["Dlocal"], 1.4987607235715452e-09, places=6
-        )

--- a/unittests/test_hydration.py
+++ b/unittests/test_hydration.py
@@ -82,7 +82,7 @@ class TestHydration(unittest.TestCase):
             "E_powers": TESTSET["E_power"],
             "T1_array": TESTSET["T1"],
             "T1_powers": TESTSET["T1_power"],
-            "magnetic_field": 348.5,
+            "magnetic_field": 0.3485,
             "spin_C": 125e-6,
             "T10": 2.0,
             "T100": 2.5,
@@ -94,7 +94,7 @@ class TestHydration(unittest.TestCase):
             "ksigma_bulk": 95.4,
             "krho_bulk": 353.4,
             "klow_bulk": 366,
-            "tcorr_bulk": 54,
+            "tcorr_bulk": 54e-12,
             "D_H2O": 2.3e-9,
             "D_SL": 4.1e-10,
             "delta_T1_water": False,
@@ -136,5 +136,5 @@ class TestHydration(unittest.TestCase):
 
         self.assertAlmostEqual(result["ksigma"], 20.17803815171555, places=6)
         self.assertAlmostEqual(result["klow"], 1286.2512443126634, places=6)
-        self.assertAlmostEqual(result["tcorr"], 485.8952027395348, places=6)
+        self.assertAlmostEqual(result["tcorr"], 485.8952027395348e-12, places=6)
         self.assertAlmostEqual(result["Dlocal"], 3.01176054373284e-10, places=6)


### PR DESCRIPTION
- [x] closes issue #214 #222 
- [ ] tests added / passed `pytest .`
- [x] passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [x] what's new:
- all units now SI (except in a couple buried functions where scipy.optimize.root_scalar doesn't do well with 1e-12 magnitude numbers. See function specific docs for which functions still use picoseconds)

The v2.0.7 hydration function took a single dictionary having two dictionaries inside, what we called a "workspace" before v2. Now since we don't have the workspace concept anymore it takes the individual dictionaries as args "data" and "constants" directly which is much more logical and less code.

With the new syntax, where you would've used a workspace:
```
workspace = dnplab.create_workspace()
workspace.add("hydration_inputs", data)
workspace.add("hydration_constants", constants)
results = dnplab.hydration(workspace)
```
or a dictionary:
```
workspace = {"hydration_inputs": data, "hydration_constants": constants}
results = dnplab.hydration(workspace)
```
now you just use:
```
results = dnplab.hydration(data, constants)
```
