### PR TITLE
Fixing Issue #295 & #284

### DIFF
--- a/dnplab/core/coord.py
+++ b/dnplab/core/coord.py
@@ -25,15 +25,23 @@ class Coords(object):
             if isinstance(coord, (range, list)):
                 coords[index] = _np.array(coord)
 
-        if self._check_dims:
-            self._dims = dims
+        if self._check_dims(dims):
+            self._dims = deepcopy(dims)
         else:
-            raise TypeError("dims must be list of str")
+            raise TypeError(
+                "dims must be list of str, you provided types {0}".format(
+                    [type(k) for k in dims]
+                )
+            )
 
-        if self._check_coords:
-            self._coords = coords
+        if self._check_coords(coords):
+            self._coords = deepcopy(coords)
         else:
-            raise TypeError("coords must be list of 1d numpy arrays")
+            raise TypeError(
+                "coords must be list of 1d numpy arrays, you provided types {0}".format(
+                    [type(k) for k in coords]
+                )
+            )
 
     def _check_dims(self, dims):
         """Verify dims is a list of str

--- a/dnplab/io/load.py
+++ b/dnplab/io/load.py
@@ -4,7 +4,7 @@ from . import *
 from ..core.util import concat
 
 
-def load(path, data_type=None, dim=None, coord=None, verbose=False, *args, **kwargs):
+def load(path, data_type=None, dim=None, coord=[], verbose=False, *args, **kwargs):
     """Import data from different spectrometer formats
 
     Args:
@@ -44,6 +44,9 @@ def load(path, data_type=None, dim=None, coord=None, verbose=False, *args, **kwa
                 filename, data_type=data_type, verbose=verbose, *args, **kwargs
             )
             data_list.append(data)
+        # coord could be empty list
+        if len(coord) == 0:
+            coord = None  # to not break concat call signature
 
         return concat(data_list, dim=dim, coord=coord)
 

--- a/unittests/test_dnp_nmr.py
+++ b/unittests/test_dnp_nmr.py
@@ -41,7 +41,7 @@ class dnpNMR_tester_sim(unittest.TestCase):
         )
 
     def test_align(self):
-        self.aligned_data = dnp.align(self.data, dim="x")
+        self.aligned_data = dnp.ndalign(self.data, dim="x")
         assert_array_equal(
             self.aligned_data.values,
             np.array(

--- a/unittests/test_nddata_core.py
+++ b/unittests/test_nddata_core.py
@@ -119,21 +119,21 @@ class dnplab_ABCData_core_tester(unittest.TestCase):
     def test_000_checkDimdeepcopy(self):
         # test for issue 295
         # this test doesn't really test anything but it checks that the functionality is as is, so this test fails if an error is raised
-        dims=['Average','t2']
-        coords1=[np.arange(0,100),np.arange(0,1024)]
-        coords2=[np.arange(0,100),np.arange(0,1024)]
-        data1=np.random.random((100,1024))
-        data2=np.random.random((100,1024))
+        dims = ["Average", "t2"]
+        coords1 = [np.arange(0, 100), np.arange(0, 1024)]
+        coords2 = [np.arange(0, 100), np.arange(0, 1024)]
+        data1 = np.random.random((100, 1024))
+        data2 = np.random.random((100, 1024))
 
-        DNPObj1=dnp.DNPData(data1,dims,coords1)
-        DNPObj2=dnp.DNPData(data2,dims,coords2)
+        DNPObj1 = dnp.DNPData(data1, dims, coords1)
+        DNPObj2 = dnp.DNPData(data2, dims, coords2)
 
-        DNPObj1=dnp.fourier_transform(DNPObj1,convert_to_ppm=False)
+        DNPObj1 = dnp.fourier_transform(DNPObj1, convert_to_ppm=False)
         # this should not raise an error
         try:
-            DNPObj2=dnp.fourier_transform(DNPObj2,convert_to_ppm=False)
+            DNPObj2 = dnp.fourier_transform(DNPObj2, convert_to_ppm=False)
         except ValueError as e:
-            self.fail('Deepcopy of dims most likely failed! Error {0}'.format(e))
+            self.fail("Deepcopy of dims most likely failed! Error {0}".format(e))
 
 
 class dnplab_ABCData_coord_tester(unittest.TestCase):
@@ -168,7 +168,6 @@ class dnplab_ABCData_coord_tester(unittest.TestCase):
 
 
 class ABCData_numpy_implementation_test(unittest.TestCase):
-
     # c&p from above for simplicity
     def construct_random_data(self):
         random_dims = random.sample(test_dims, random.randint(1, len(test_dims)))
@@ -222,6 +221,8 @@ class ABCData_numpy_implementation_test(unittest.TestCase):
 
         self.assertEqual(type(b), type(rdata))
         self.assertEqual(test_sum.shape, b.shape)
-        self.assertTrue( np.all( np.isclose(test_sum - b._values, 0)) )  # check for value equality
+        self.assertTrue(
+            np.all(np.isclose(test_sum - b._values, 0))
+        )  # check for value equality
         self.assertFalse(dims[0] in b.dims)
-        self.assertRaises(ValueError,np.sum,b,axis='doesnotexist')
+        self.assertRaises(ValueError, np.sum, b, axis="doesnotexist")

--- a/unittests/test_nddata_core.py
+++ b/unittests/test_nddata_core.py
@@ -119,6 +119,8 @@ class dnplab_ABCData_core_tester(unittest.TestCase):
     def test_000_checkDimdeepcopy(self):
         # test for issue 295
         # this test doesn't really test anything but it checks that the functionality is as is, so this test fails if an error is raised
+        # uses dnplab
+        import dnplab as dnp
         dims = ["Average", "t2"]
         coords1 = [np.arange(0, 100), np.arange(0, 1024)]
         coords2 = [np.arange(0, 100), np.arange(0, 1024)]

--- a/unittests/test_nddata_core.py
+++ b/unittests/test_nddata_core.py
@@ -116,6 +116,25 @@ class dnplab_ABCData_core_tester(unittest.TestCase):
 
         self.assertEqual(data.ndim, 2)
 
+    def test_000_checkDimdeepcopy(self):
+        # test for issue 295
+        # this test doesn't really test anything but it checks that the functionality is as is, so this test fails if an error is raised
+        dims=['Average','t2']
+        coords1=[np.arange(0,100),np.arange(0,1024)]
+        coords2=[np.arange(0,100),np.arange(0,1024)]
+        data1=np.random.random((100,1024))
+        data2=np.random.random((100,1024))
+
+        DNPObj1=dnp.DNPData(data1,dims,coords1)
+        DNPObj2=dnp.DNPData(data2,dims,coords2)
+
+        DNPObj1=dnp.fourier_transform(DNPObj1,convert_to_ppm=False)
+        # this should not raise an error
+        try:
+            DNPObj2=dnp.fourier_transform(DNPObj2,convert_to_ppm=False)
+        except ValueError as e:
+            self.fail('Deepcopy of dims most likely failed! Error {0}'.format(e))
+
 
 class dnplab_ABCData_coord_tester(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
warning: pull reqeust might break usercode (see last point)!

fixed issue #295
fixed issue #284
fixed depcrecation warning :
\unittests\test_dnp_nmr.py:44: DeprecationWarning: This function is deprecated. Please use ndalign instead. align will be removed after 01/01/2023
    self.aligned_data = dnp.align(self.data, dim="x")

by doing what the warning said (replaced align with ndalign)

fixed check in class Coords: check for _check_dims and _check_coords was always true, now it does test dims and coords
Note: this might break usercode... but this is because the check now fails as it should!
