### PR TITLE
forwarding of different plots to matplotlib

### DIFF
--- a/dnplab/io/load_csv.py
+++ b/dnplab/io/load_csv.py
@@ -69,7 +69,7 @@ def load_csv(
     if "delimiter" in kwargs.keys():
         delimiter = kwargs.pop("delimiter")
 
-    dims = kwargs.pop("dims", "t2")
+    dims = kwargs.pop("dims", ["t2"])
 
     def _checknone(x, row, ind=None):
         if x is None and (ind is not None):

--- a/dnplab/io/load_csv.py
+++ b/dnplab/io/load_csv.py
@@ -68,10 +68,8 @@ def load_csv(
 
     if "delimiter" in kwargs.keys():
         delimiter = kwargs.pop("delimiter")
-    if "dims" in kwargs.keys():
-        dims = kwargs["dims"]
-    else:
-        dims = ["t2"]
+
+    dims = kwargs.pop("dims", "t2")
 
     def _checknone(x, row, ind=None):
         if x is None and (ind is not None):

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -69,11 +69,13 @@ def plot(data, *args, **kwargs):
     # no unittest added, but only hand tested with semilogy and normal plot works as intended ni fancy_plot)
     #
     use_default=True
+    plot_function_list=[]
     for k in forwarded_pyplot_plots:
         if bool(kwargs.pop(k,None)):
-            plt_function=getattr(plt,k)
-            plt_function(coord, data.values.real, *args,**kwargs )
+            plot_function_list.append(getattr(plt,k))
             use_default=False
+    for f in plot_function_list:
+        f(coord, data.values.real, *args,**kwargs )
     if use_default:
         plt.plot(coord, data.values.real, *args, **kwargs)
     data.fold()

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -17,6 +17,8 @@ plt.rcParams["axes.prop_cycle"] = plt.cycler(
 
 show = plt.show
 
+# hand curated list of plotting arguments that are forwarded, note that this should probably be in a config file (refactoring needed)
+forwarded_pyplot_plots=['semilogy', "semilogx", "polar", "loglog", "scatter", "errorbar", "step" ]
 
 def plot(data, *args, **kwargs):
     """Plot function for dnpdata object
@@ -63,13 +65,17 @@ def plot(data, *args, **kwargs):
 
     data.unfold(dim)
 
-    plot_semilogy = kwargs.pop("semilogy", None) is not None
-    if plot_semilogy:
-        plt.semilogy(coord, data.values.real, *args, **kwargs)
-        data.fold()
-        return
-    # default
-    plt.plot(coord, data.values.real, *args, **kwargs)
+    # will try to plot various pyplot utility plot functions into same axis, the use should know what he does!
+    # no unittest added, but only hand tested with semilogy and normal plot works as intended ni fancy_plot)
+    #
+    use_default=True
+    for k in forwarded_pyplot_plots:
+        if bool(kwargs.pop(k,None)):
+            plt_function=getattr(plt,k)
+            plt_function(coord, data.values.real, *args,**kwargs )
+            use_default=False
+    if use_default:
+        plt.plot(coord, data.values.real, *args, **kwargs)
     data.fold()
 
 

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -26,6 +26,8 @@ def plot(data, *args, **kwargs):
         args: args for matplotlib plot function
         kwargs: kwargs for matplotlib plot function
 
+        if semilogy=x is in kwargs and x is not None a semilogy axis will be used
+
     Returns:
         Returns formated matplotlib plot.
 
@@ -61,6 +63,12 @@ def plot(data, *args, **kwargs):
 
     data.unfold(dim)
 
+    plot_semilogy = kwargs.pop("semilogy", None) is not None
+    if plot_semilogy:
+        plt.semilogy(coord, data.values.real, *args, **kwargs)
+        data.fold()
+        return
+    # default
     plt.plot(coord, data.values.real, *args, **kwargs)
     data.fold()
 

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -37,7 +37,8 @@ def plot(data, *args, **kwargs):
         args: args for matplotlib plot function
         kwargs: kwargs for matplotlib plot function
 
-        if semilogy=x is in kwargs and x is not None a semilogy axis will be used
+        if any of semilogy, semilogx, polar, loglog, scatter, errorbar or step is in kwargs the argument will be evaluated with
+        bool(). If this evaluates to True the corresponding matplotlib function is used instead of the standard plot
 
     Returns:
         Returns formated matplotlib plot.
@@ -61,6 +62,14 @@ def plot(data, *args, **kwargs):
 
        >>> dnp.plt.figure()
        >>> dnp.plot(data, 'k-', linewidth = 3.0, alpha = 0.5)
+       >>> dnp.plt.show()
+
+       Plotting a DNPData object with a semilogy plot (possible arguments: semilogy=1, semilogy=True, semilogy="True")
+       Forwarded arguments: semilogy, semilogx, polar, loglog, scatter, errorbar or step
+       The absolute value is taken to ensure that the y axis is always positive
+
+       >>> dnp.plt.figure()
+       >>> dnp.plot(np.abs(data), 'k-', linewidth = 3.0, alpha = 0.5, semilogy=1)
        >>> dnp.plt.show()
 
     """

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -18,7 +18,16 @@ plt.rcParams["axes.prop_cycle"] = plt.cycler(
 show = plt.show
 
 # hand curated list of plotting arguments that are forwarded, note that this should probably be in a config file (refactoring needed)
-forwarded_pyplot_plots=['semilogy', "semilogx", "polar", "loglog", "scatter", "errorbar", "step" ]
+forwarded_pyplot_plots = [
+    "semilogy",
+    "semilogx",
+    "polar",
+    "loglog",
+    "scatter",
+    "errorbar",
+    "step",
+]
+
 
 def plot(data, *args, **kwargs):
     """Plot function for dnpdata object
@@ -67,15 +76,14 @@ def plot(data, *args, **kwargs):
 
     # will try to plot various pyplot utility plot functions into same axis, the use should know what he does!
     # no unittest added, but only hand tested with semilogy and normal plot works as intended ni fancy_plot)
-    #
-    use_default=True
-    plot_function_list=[]
+    use_default = True
+    plot_function_list = []
     for k in forwarded_pyplot_plots:
-        if bool(kwargs.pop(k,None)):
-            plot_function_list.append(getattr(plt,k))
-            use_default=False
+        if bool(kwargs.pop(k, None)):
+            plot_function_list.append(getattr(plt, k))
+            use_default = False
     for f in plot_function_list:
-        f(coord, data.values.real, *args,**kwargs )
+        f(coord, data.values.real, *args, **kwargs)
     if use_default:
         plt.plot(coord, data.values.real, *args, **kwargs)
     data.fold()


### PR DESCRIPTION
if any of 
semilogy, semilogx, polar, loglog, scatter, errorbar or step 
is in kwargs

dnp.plot will evaluate the argument with bool() and if it evaluates to True it will use the corresponding matplotlib function.
Added a semilogy example to the reference documentation
the allowed arguments are in the hand curated list io/plotting/general.py forwarded_pyplot_plots

passes all checks, no new unittest added but fieldtested