### PR TITLE
Bugfixes bkaribo 1

### DIFF
--- a/dnplab/core/base.py
+++ b/dnplab/core/base.py
@@ -1090,7 +1090,7 @@ class ABCData(object):
                 else possible_dim
             )
             data_dims = []
-            proc_dims=[]
+            proc_dims = []
             # replace e.g. 'f2' with corresponding dim
             while True:
                 if "axis" in kwargs.keys():
@@ -1118,7 +1118,7 @@ class ABCData(object):
                 kwargs["axis"] = indx
                 break
 
-            #apply function to values
+            # apply function to values
             return_values = func(*args, **kwargs)
         if type(return_values) == _np.ndarray:
             a = self.copy()
@@ -1128,12 +1128,12 @@ class ABCData(object):
             a.values = return_values
 
             # add processing attributes
-            proc_attr_name = "numpy."+func.__name__
+            proc_attr_name = "numpy." + func.__name__
             proc_parameters = {"axis": proc_dims}
             try:
                 a.add_proc_attrs(proc_attr_name, proc_parameters)
             except AttributeError:
-                pass #would log error here
+                pass  # would log error here
 
             return a
         # if not ndarray then return as is

--- a/dnplab/processing/helpers.py
+++ b/dnplab/processing/helpers.py
@@ -53,38 +53,49 @@ def calculate_enhancement(data, off_spectrum_index=0, return_complex_values=Fals
 
 def signal_to_noise(
     data: DNPData,
-    signal_region: list,
-    noise_region: list,
+    signal_region: list = slice(0, None),
+    noise_region: list = (None, None),
     dim: str = "f2",
     remove_background: list = None,
-    fullOutput: bool = False,
     **kwargs
 ):
     """Find signal-to-noise ratio
 
-    Simplest implementation: select largest value in a signal_region and divide this value by the estimated std. of the baseline in another region
-
-    The signature of this function is not final and is subject to changes - do use at your own risk!
+    Simplest implementation: select largest value in a signal_region and divide this value by the estimated std. deviation of another noise_region. If the noise_region list contains (None,None) (the default) then all points except the points +10% and -10% around the maximum are used for the noise_region.
 
     Args:
         data: Spectrum data
-        signal_region : tuple (start,stop) of region where signal should be searched
-        noise_region : tuple (start,stop) of region that should be taken as noise
-        dim (default f2): dimension of data that is used for snr
-        remove_background :listl=None, if this is not none (a list of tuples, or a single tuple) this will be forwarded to dnp.remove_background, tgether with any kwargs
-        fullOutput:bool=False whether signal and noise should also be returned
+        signal_region (list): list with a single tuple (start,stop) of a region where a signal should be searched, default is [slice(0,None)] which is the whole spectrum
+        noise_region (list): list with tuples (start,stop) of regions that should be taken as noise, default is (None,None)
+        dim (str): dimension of data that is used for snr calculation, default is 'f2'
+        remove_background (list): if this is not None (a list of tuples, or a single tuple) this will be forwarded to dnp.remove_background, together with any kwargs
+        kwargs : parameters for dnp.remove_background
 
     Returns:
-        data: DNPData, snr:float
-        or:
-        data: DNPData, snr:float, signal:float, noise: float
+        SNR (float): Signal to noise ratio
+
+    Examples:
+
+        A note for the usage: regions can be provided as (min,max), slices use indices.
+        To use the standard values just use
+
+            >>> snr = dnp.signal_to_noise(data)
+
+        If you want to select a region for the noise and the signal:
+
+            >>> snr = dnp.signal_to_noise(data,[(-1.23,300.4)],noise_region=[(-400,-240.5),(123.4,213.5)])
+
+        With background subtracted:
+
+            >>> snr = dnp.signal_to_noise(data,[(-1.23,300.4)],noise_region=[(-400,-240.5),(123.4,213.5)],remove_background=[(123.4,213.5)])
+
+        This function allows to use a single tuple instead of a list with a single tuple for signal_region, noise_region and remove_background. This is for convenience, slices are currently only supoprted for signal_region and noise_region.
+
+            >>> snr = dnp.signal_to_noise(data,(-1.23,300.4),noise_region=[(-400,-240.5),(123.4,213.5],remove_background=(123.4,213.5))
+
     """
     import warnings
     import scipy.optimize as _scipy_optimize
-
-    warnings.warn(
-        "helpers.signal_to_noise: The signature and implementation of this function is not final and is subject to changes - do use at your own risk!"
-    )
 
     # convenience for signal and noise region
     def _convenience_tuple_to_list(possible_region: list):
@@ -94,9 +105,9 @@ def signal_to_noise(
         try:
             l = len(possible_region)
             if l != 2:
-                return possible_region
+                return possible_region  # it seems to be iterable?
         except TypeError:
-            return possible_region  # return as is
+            return [possible_region]  # return as is in a list, might be slice
         try:
             # check whether we can interpret it as value
             a = int(possible_region[0])
@@ -104,11 +115,22 @@ def signal_to_noise(
                 (possible_region[0], possible_region[1])
             ]  # make a list that contains a tuple
         except TypeError:
-            return possible_region
+            if type(possible_region) == list:
+                return possible_region
+            return [possible_region]
 
     signal_region = _convenience_tuple_to_list(signal_region)
+    if len(signal_region) > 1:
+        raise ValueError(
+            "More than one signal region ({0}) provided in signal_to_noise. This is not supported.".format(
+                signal_region
+            )
+        )
     noise_region = _convenience_tuple_to_list(noise_region)
     remove_background = _convenience_tuple_to_list(remove_background)
+
+    if not (dim in data.dims):
+        raise ValueError("dim {0} not in data.dims ({1})".format(dim, data.dims))
 
     # remove background
     if remove_background is not None:
@@ -117,11 +139,24 @@ def signal_to_noise(
 
     # currently only one method avaiable -> absolute value
     signal = _np.max(_np.abs(data[dim, signal_region[0]]))
-    noise = _np.std(_np.abs(data[dim, noise_region[0]]))
 
-    if fullOutput:
-        return data, signal / noise, signal, noise
-    return data, signal / noise
+    if (None, None) in noise_region:
+        signal_arg = _np.argmax(_np.abs(data[dim, signal_region[0]]))
+        datasize = data[dim, :].size
+        noise_region = [
+            slice(0, int(_np.maximum(2, int(signal_arg * 0.9)))),
+            slice(int(_np.minimum(datasize - 2, int(signal_arg * 1.1))), None),
+        ]
+
+    # concatenate noise_regions
+    noise_0 = _np.abs(data[dim, noise_region[0]])
+
+    for k in noise_region[1:]:
+        noise_0.concatenate(_np.abs(data[dim, k]), dim)
+
+    noise = _np.std(_np.abs(noise_0[dim, slice(0, None)]))
+
+    return signal / noise
 
 
 def smooth(data, dim="t2", window_length=11, polyorder=3):

--- a/unittests/test_data_class.py
+++ b/unittests/test_data_class.py
@@ -12,6 +12,13 @@ class dnpDataTester(unittest.TestCase):
             self.gauss_3d, ["x", "y", "z"], [self.x, self.y, self.z]
         )
 
+        self.size = 10
+        self.d = np.random.random((self.size,self.size))
+
+        self.ax=np.arange(self.size)
+        self.Ddata = dnp.DNPData(self.d,dims=['1','2'],coords=[self.ax,self.ax])
+
+
     def test_DNPData(self):
         assertArrayEqual(self.data.coords["x"], self.x)
         assertArrayEqual(self.data.dims, ["x", "y", "z"])
@@ -30,6 +37,23 @@ class dnpDataTester(unittest.TestCase):
         assertArrayEqual(self.data.dims, ["x", "y", "z"])
         assertArrayEqual(self.data.coords["z"], self.z)
 
+    def test_000_checkProcDim(self):
+        f=np.sin
+        f2=np.max
+
+        tdata=f2(self.Ddata,axis='1')
+
+        if not ('numpy.amax' in tdata.proc_attrs[0]):
+            self.fail('Assertion that np.max is in proc_attrs is False, proc_attrs:{0}'.format(tdata.proc_attrs))
+        if not (tdata.proc_attrs[-1][1]['axis']==['1']):
+            self.fail("Assertion that axis is {0} is False, tdata.proc_attrs[-1]:{1}".format('1',tdata.proc_attrs[-1][1]))
+
+        tdata2=f2(self.Ddata)
+
+        try:
+            float(tdata2)
+        except ValueError:
+            self.fail("tdata2 is not something like a float: {0}".format(tdata2))
 
 if __name__ == "__main__":
     pass

--- a/unittests/test_data_class.py
+++ b/unittests/test_data_class.py
@@ -13,11 +13,10 @@ class dnpDataTester(unittest.TestCase):
         )
 
         self.size = 10
-        self.d = np.random.random((self.size,self.size))
+        self.d = np.random.random((self.size, self.size))
 
-        self.ax=np.arange(self.size)
-        self.Ddata = dnp.DNPData(self.d,dims=['1','2'],coords=[self.ax,self.ax])
-
+        self.ax = np.arange(self.size)
+        self.Ddata = dnp.DNPData(self.d, dims=["1", "2"], coords=[self.ax, self.ax])
 
     def test_DNPData(self):
         assertArrayEqual(self.data.coords["x"], self.x)
@@ -38,22 +37,31 @@ class dnpDataTester(unittest.TestCase):
         assertArrayEqual(self.data.coords["z"], self.z)
 
     def test_000_checkProcDim(self):
-        f=np.sin
-        f2=np.max
+        f = np.sin
+        f2 = np.max
 
-        tdata=f2(self.Ddata,axis='1')
+        tdata = f2(self.Ddata, axis="1")
 
-        if not ('numpy.amax' in tdata.proc_attrs[0]):
-            self.fail('Assertion that np.max is in proc_attrs is False, proc_attrs:{0}'.format(tdata.proc_attrs))
-        if not (tdata.proc_attrs[-1][1]['axis']==['1']):
-            self.fail("Assertion that axis is {0} is False, tdata.proc_attrs[-1]:{1}".format('1',tdata.proc_attrs[-1][1]))
+        if not ("numpy.amax" in tdata.proc_attrs[0]):
+            self.fail(
+                "Assertion that np.max is in proc_attrs is False, proc_attrs:{0}".format(
+                    tdata.proc_attrs
+                )
+            )
+        if not (tdata.proc_attrs[-1][1]["axis"] == ["1"]):
+            self.fail(
+                "Assertion that axis is {0} is False, tdata.proc_attrs[-1]:{1}".format(
+                    "1", tdata.proc_attrs[-1][1]
+                )
+            )
 
-        tdata2=f2(self.Ddata)
+        tdata2 = f2(self.Ddata)
 
         try:
             float(tdata2)
         except ValueError:
             self.fail("tdata2 is not something like a float: {0}".format(tdata2))
+
 
 if __name__ == "__main__":
     pass

--- a/unittests/test_dnp_tools.py
+++ b/unittests/test_dnp_tools.py
@@ -32,6 +32,8 @@ class dnpTools_tester(unittest.TestCase):
         alot of simple tests lumped together
 
         Missing: check whether signal and noise are scalar values
+
+        note that these tests are not really unittests but more integration tests
         """
         f = dnp.processing.signal_to_noise
 
@@ -40,52 +42,54 @@ class dnpTools_tester(unittest.TestCase):
         data = dnp.fourier_transform(self.data)
 
         try:
-            data, snr = f(data, (300, 400), (500, 600))
+            snr = f(data, (300, 400), (500, 600))
         except ValueError as e:
             self.fail("signal_to_noise reported ValueError {0}".format(e))
         self.assertTrue(not np.isnan(snr))
 
-        dat, snr, signal, noise = f(
-            data, (300, 400), (500, 600), fullOutput=True, detrend=False
+        snr = f(
+            data,
+            (300, 400),
+            (500, 600),
         )
-
-        self.assertTrue(not np.isnan(snr))
-        self.assertTrue(not np.isnan(signal))
-        self.assertTrue(not np.isnan(noise))
 
     def test_001_using_different_dimensions(self):
         f = dnp.processing.signal_to_noise
         data = dnp.fourier_transform(self.data)
 
         # some input checks, just to check that no errors are thrown:
-        dat, snr = f(data, [(300, 400)], [(500, 600)])
-        self.assertTrue(data._values.size > 0)  # check for existing data
-        dat, snr = f(
+        snr = f(data, [(300, 400)], [(500, 600)])
+        snr = f(
             data, [(300, 400)], [(500, 600)], remove_background=(100, 200), deg=3
         )  # works with degree
-        dat, snr = f(
+        snr = f(
             data, [(300, 400)], [(500, 600)], remove_background=(100, 200)
         )  # works without degree
-        dat, snr = f(
+        snr = f(
             data, [(300, 400)], [(500, 600)], remove_background=[(100, 200)]
         )  # works with list as intended
-        dat, snr = f(
+        snr = f(
             data, [(-121.5, 104.1)], [(632.5, 1264.2)], remove_background=[(100, 200)]
         )
-        dat, snr = f(
+        snr = f(
             data,
             [(-121.5, 104.1)],
             [(632.5, 1264.2)],
             remove_background=[(-1300.1, -500.0)],
         )
-        """
-        dat, snr = f(
-            data, [100:300], [300:400], remove_background=[80:500]
+        # with defaults
+        snr = f(data)
+        # with slices
+        snr = f(data, slice(0, None), remove_background=[(100, 200)])
+        self.assertRaises(ValueError, f, data, [slice(0, None), (100, 300)])
+        snr2 = f(data, (0, 1000), remove_background=[(100, 200)])
+
+        snr = f(
+            data,
+            slice(0, None),
+            [slice(0, 100), slice(500, 600)],
+            remove_background=[(100, 200)],
         )
-        dat, snr = f(
-            data, 100:300, 300:400, remove_background=[80:500]
-        )
-        """
 
     def test_integrate(self):
         dnp.integrate(self.data, dim="t2")

--- a/unittests/test_nddata_core.py
+++ b/unittests/test_nddata_core.py
@@ -121,6 +121,7 @@ class dnplab_ABCData_core_tester(unittest.TestCase):
         # this test doesn't really test anything but it checks that the functionality is as is, so this test fails if an error is raised
         # uses dnplab
         import dnplab as dnp
+
         dims = ["Average", "t2"]
         coords1 = [np.arange(0, 100), np.arange(0, 1024)]
         coords2 = [np.arange(0, 100), np.arange(0, 1024)]
@@ -136,6 +137,7 @@ class dnplab_ABCData_core_tester(unittest.TestCase):
             DNPObj2 = dnp.fourier_transform(DNPObj2, convert_to_ppm=False)
         except ValueError as e:
             self.fail("Deepcopy of dims most likely failed! Error {0}".format(e))
+
 
 class dnplab_ABCData_coord_tester(unittest.TestCase):
     def setUp(self):
@@ -186,14 +188,14 @@ class ABCData_numpy_implementation_test(unittest.TestCase):
         self.a = np.zeros(self.size)
         self.b = np.ones(self.size)
         self.c = self.val * np.ones(self.size)
-        self.d = np.random.random((self.size,self.size))
+        self.d = np.random.random((self.size, self.size))
 
-        self.ax=np.arange(self.size)
+        self.ax = np.arange(self.size)
 
         self.Adata = ABCData(self.a)
         self.Bdata = ABCData(self.b)
         self.Cdata = ABCData(self.c)
-        self.Ddata = ABCData(self.d,dims=['1','2'],coords=[self.ax,self.ax])
+        self.Ddata = ABCData(self.d, dims=["1", "2"], coords=[self.ax, self.ax])
 
     def test_000_replaceAttr(self):
         from dnplab.core.base import _replaceClassWithAttribute
@@ -231,6 +233,3 @@ class ABCData_numpy_implementation_test(unittest.TestCase):
         )  # check for value equality
         self.assertFalse(dims[0] in b.dims)
         self.assertRaises(ValueError, np.sum, b, axis="doesnotexist")
-
-
-

--- a/unittests/test_nddata_core.py
+++ b/unittests/test_nddata_core.py
@@ -137,7 +137,6 @@ class dnplab_ABCData_core_tester(unittest.TestCase):
         except ValueError as e:
             self.fail("Deepcopy of dims most likely failed! Error {0}".format(e))
 
-
 class dnplab_ABCData_coord_tester(unittest.TestCase):
     def setUp(self):
         self.coord_inst_a = np.r_[0:10:1]
@@ -187,10 +186,14 @@ class ABCData_numpy_implementation_test(unittest.TestCase):
         self.a = np.zeros(self.size)
         self.b = np.ones(self.size)
         self.c = self.val * np.ones(self.size)
+        self.d = np.random.random((self.size,self.size))
+
+        self.ax=np.arange(self.size)
 
         self.Adata = ABCData(self.a)
         self.Bdata = ABCData(self.b)
         self.Cdata = ABCData(self.c)
+        self.Ddata = ABCData(self.d,dims=['1','2'],coords=[self.ax,self.ax])
 
     def test_000_replaceAttr(self):
         from dnplab.core.base import _replaceClassWithAttribute
@@ -228,3 +231,6 @@ class ABCData_numpy_implementation_test(unittest.TestCase):
         )  # check for value equality
         self.assertFalse(dims[0] in b.dims)
         self.assertRaises(ValueError, np.sum, b, axis="doesnotexist")
+
+
+


### PR DESCRIPTION
- closes issue #310 
- closes issue #250
- added new test to check for proc_attributes when numpy functions are used on a dnpdata object
- reformatted with black

- improved documentation of signal_to_noise ratio function so that it is clearer that it has the same call signature as standard DNPLab functions
