### PR TITLE
Make a condition to  assign dnplab_attrs

### DIFF
--- a/dnplab/io/load.py
+++ b/dnplab/io/load.py
@@ -124,7 +124,9 @@ def load_file(path, data_format=None, verbose=False, *args, **kwargs):
     else:
         raise ValueError("Invalid data format: %s" % data_format)
 
-    data = _assign_dnplab_attrs(data, data_format)
+    if data_format not in ["h5", "power", "vna", "cnsi_powers"]:
+        data = _assign_dnplab_attrs(data, data_format)
+
     return data
 
 


### PR DESCRIPTION
When loading 5f file, the dnplab_attrs shouldn't been assigned from dnplab_config file because they have been already stored in the h5 file. This pull request fix the issue and now the dnplab_attrs are assigned from the h5 file directly.