### PR TITLE
Adding convert_power function to be compatible with different input data type 

### DIFF
--- a/dnplab/processing/conversion.py
+++ b/dnplab/processing/conversion.py
@@ -7,17 +7,23 @@ def dBm2w(power_in_dBm):
     Convert a microwave power given in dBm to W. Note that for values <= -190 dBm the output power in W is set to 0.
 
     Args:
-        power_in_dBm: Power in (dBm)
+        power_in_dBm (array, list, float or int): Power in (dBm)
 
     Returns:
-        float (array): Power in (W)
+        float (array, list, float or int): Power in (W)
 
-    """
+    """  
 
-    power_in_W = 10.0 ** (power_in_dBm / 10.0) / 1000.0
-
-    # Set values below 1 pW to 0 W
-    power_in_W[power_in_W <= 1e-22] = 0
+    if isinstance(power_in_dBm, (_np.ndarray, list)):
+        power_in_W = power_in_dBm.copy()
+        for index in range(len(power_in_dBm)):
+            power_in_W[index] = dBm2w(power_in_dBm[index])
+        return power_in_W
+    
+    else:
+        power_in_W = 10.0 ** (power_in_dBm / 10.0) / 1000.0
+        # Set values below 1 pW to 0 W
+        power_in_W = 0 if power_in_W <= 1e-22 else power_in_W
 
     return power_in_W
 

--- a/dnplab/processing/conversion.py
+++ b/dnplab/processing/conversion.py
@@ -34,11 +34,20 @@ def w2dBm(power_in_W):
     Convert a microwave power given in W to dBm
 
     Args:
-        power_in_W:   Power in (W)
+        power_in_W (array, list, float or int):   Power in (W)
+    
+    Returns:
+        float (array, list, float or int): Power in (W)
 
     """
-
-    power_in_dBm = 10.0 * _np.log10(1000 * power_in_W)
+    if isinstance(power_in_W, (_np.ndarray, list)):
+        power_in_dBm = power_in_W.copy()
+        for index in range(len(power_in_W)):
+            power_in_dBm[index] = w2dBm(power_in_W[index])
+        return power_in_dBm
+    
+    else:
+        power_in_dBm = 10.0 * _np.log10(1000 * power_in_W)
 
     return power_in_dBm
 


### PR DESCRIPTION
The old dBm2w and w2dBm functions can only accept numpy array as input. Even integer and float are not acceptable by dBm2w function.

This pull request has solved this issue. Now dBm2w and w2dBm functions can accept numpy array, list, integer and float. They will return the same data type as input.

Additionally, the new function 'convert_power' was added, which is compatible with DNPData Objects. It accepts DNPData object as input, and will return DNPData objects with the new DNPLab_attrs: power_unit and the proc_attrs. It will automatically convert power if 'power_unit' is in DNPLab_attrs. Besides, it works with numpy array, list, float and integer.