### PR TITLE
Correct the argument in np.linspace

### DIFF
--- a/dnplab/io/winepr.py
+++ b/dnplab/io/winepr.py
@@ -157,7 +157,7 @@ def load_spc(path, attrs):
             coords = [
                 _np.linspace(
                     attrs["sweep_start"],
-                    attrs["sweep_extent"],
+                    attrs["sweep_start"] + attrs["sweep_extent"],
                     attrs["x_points"],
                 )
             ]


### PR DESCRIPTION
The np.linspace() needs three arguments: start, end, number of points