### PR TITLE
changed behavior of __getitem__ for coords access

### DIFF
--- a/dnplab/core/base.py
+++ b/dnplab/core/base.py
@@ -303,11 +303,14 @@ class ABCData(object):
                     updated_index_slice.append(slice(start, start + 1))
                 else:
                     start = _np.argmin(_np.abs(slice_[0] - a.get_coord(dim)))
-                    stop = _np.argmin(_np.abs(slice_[1] - a.get_coord(dim)))
-                    if start == stop:
-                        stop = start + 1
-                    if stop < start:
-                        start, stop = stop, start
+                    if slice_[1] > a._coords[dim][-1]:
+                        stop = None
+                    else:
+                        stop = _np.argmin(_np.abs(slice_[1] - a.get_coord(dim)))
+                        if start == stop:
+                            stop = start + 1
+                        if stop < start:
+                            start, stop = stop, start
                     updated_index_slice.append(slice(start, stop))
             elif isinstance(slice_, int):
                 start = slice_

--- a/examples/02_Analysis/plot_03_peak_linewidth.py
+++ b/examples/02_Analysis/plot_03_peak_linewidth.py
@@ -22,10 +22,10 @@ data.attrs["experiment_type"] = "nmr_spectrum"
 
 data = dnp.apodize(data, lw=2)
 data = dnp.fourier_transform(data)
-data = dnp.phase(data, p0 = 175)
+data = dnp.phase(data, p0=175)
 
 dnp.plt.figure()
-dnp.fancy_plot(data, xlim = [-20,20])
+dnp.fancy_plot(data, xlim=[-20, 20])
 dnp.plt.title("ODNP-Enhanced NMR Spectrum of 10 mM TEMPONE in Toluene")
 dnp.plt.show()
 
@@ -47,7 +47,7 @@ dnp.peak_info(peaks)
 # ---------------------
 # By default, *find_peaks* will identify every feature in the spectrum with a amplitude > 5 % of the maximum intensity as a peak. For this, the spectrum is first normalized to a maximum amplitude of 1. This default value can be change as shown in the next line
 
-peaks = dnp.find_peaks(data, threshold = 0.6)
+peaks = dnp.find_peaks(data, threshold=0.6)
 dnp.peak_info(peaks)
 
 # %%

--- a/unittests/test_average.py
+++ b/unittests/test_average.py
@@ -7,20 +7,22 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class dnpTools_tester(unittest.TestCase):
     def setUp(self):
         avg_dim = "Average"
         avg_x = np.r_[0:4]
         dim = "x"
         x = np.r_[0:10]
-        y = np.array([x**2 * (i+1) for i in avg_x])
+        y = np.array([x**2 * (i + 1) for i in avg_x])
         self.data = dnp.DNPData(y, [avg_dim, dim], [avg_x, x])
-        self.avg_values = np.mean(y, axis = 0)
+        self.avg_values = np.mean(y, axis=0)
 
     def test_average_function(self):
         avg_data = dnp.average(self.data)
         assert_array_equal(self.data.coords["x"], avg_data.coords["x"])
         assert_array_equal(avg_data.values, self.avg_values)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unittests/test_fft.py
+++ b/unittests/test_fft.py
@@ -7,6 +7,7 @@ import logging
 # logging.basicConfig(filename='phase_debug.log', encoding='utf-8', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class dnpNMR_tester(unittest.TestCase):
     def setUp(self):
         pts = 1024
@@ -18,8 +19,9 @@ class dnpNMR_tester(unittest.TestCase):
         self.data.attrs["nmr_frequency"] = 400e6
 
     def test_fourier_transform_functions(self):
-        self.data = dnp.fourier_transform(self.data, zero_fill_factor = 4)
+        self.data = dnp.fourier_transform(self.data, zero_fill_factor=4)
         self.data = dnp.inverse_fourier_transform(self.data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
-  closes issue #420
- passed `pytest .` - since this changes __getitem__ maybe this pullrequest should be deferred until unittests have been introduced
- passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`

inserted possible None for the slice ending in __getitem__ on ABCData, note that if start is the last slice this might now result in a possible empty dataset, it should be discussed whether this can be tolerated
