### PR TITLE
Feature autophase revisited

### DIFF
--- a/dnplab/processing/phase.py
+++ b/dnplab/processing/phase.py
@@ -113,8 +113,7 @@ def autophase(
             p0=ph0 / 2 / _const.pi * 360,
             p1=ph1 / 2 / _const.pi * 360,
         )
-        # if verbose:
-        #    data.proc_attrs[-2][1]["phasetuples"].append((ph0, ph1))
+
     return data
 
 

--- a/dnplab/processing/phase.py
+++ b/dnplab/processing/phase.py
@@ -113,7 +113,7 @@ def autophase(
             p0=ph0 / 2 / _const.pi * 360,
             p1=ph1 / 2 / _const.pi * 360,
         )
-        #if verbose:
+        # if verbose:
         #    data.proc_attrs[-2][1]["phasetuples"].append((ph0, ph1))
     return data
 

--- a/dnplab/processing/phase.py
+++ b/dnplab/processing/phase.py
@@ -113,8 +113,8 @@ def autophase(
             p0=ph0 / 2 / _const.pi * 360,
             p1=ph1 / 2 / _const.pi * 360,
         )
-        if verbose:
-            data.proc_attrs[-2][1]["phasetuples"].append((ph0, ph1))
+        #if verbose:
+        #    data.proc_attrs[-2][1]["phasetuples"].append((ph0, ph1))
     return data
 
 

--- a/examples/02_Analysis/plot_03_peak_linewidth.py
+++ b/examples/02_Analysis/plot_03_peak_linewidth.py
@@ -47,7 +47,7 @@ dnp.peak_info(peaks)
 # ---------------------
 # By default, *find_peaks* will identify every feature in the spectrum with a amplitude > 5 % of the maximum intensity as a peak. For this, the spectrum is first normalized to a maximum amplitude of 1. This default value can be change as shown in the next line
 
-peaks = dnp.find_peaks(data, height = 0.6)
+peaks = dnp.find_peaks(data, height=0.6)
 dnp.peak_info(peaks)
 
 # %%


### PR DESCRIPTION
- closes issue #434
- no test added / passed `pytest .`
- passes `black .`

removed verbose check and adding of attributes to DNP objects
