### PR TITLE
Feature autophase revisited

### DIFF
--- a/dnplab/processing/phase.py
+++ b/dnplab/processing/phase.py
@@ -81,7 +81,9 @@ def autophase(
             coords = data.coords[dim]
             ph0, ph1 = _autophase(spectrum, coords, dim, deriv, gamma)
             if full_proc_attr:
-                data.proc_attrs[-1][1]["phasetuples"].append((ph0/_const.pi*180, ph1/_const.pi*180))
+                data.proc_attrs[-1][1]["phasetuples"].append(
+                    (ph0 / _const.pi * 180, ph1 / _const.pi * 180)
+                )
         for phasetpl, indx in zip(
             data.proc_attrs[-1][1]["phasetuples"], range(n_spectra)
         ):

--- a/dnplab/processing/phase.py
+++ b/dnplab/processing/phase.py
@@ -81,7 +81,7 @@ def autophase(
             coords = data.coords[dim]
             ph0, ph1 = _autophase(spectrum, coords, dim, deriv, gamma)
             if full_proc_attr:
-                data.proc_attrs[-1][1]["phasetuples"].append((ph0, ph1))
+                data.proc_attrs[-1][1]["phasetuples"].append((ph0/_const.pi*180, ph1/_const.pi*180))
         for phasetpl, indx in zip(
             data.proc_attrs[-1][1]["phasetuples"], range(n_spectra)
         ):
@@ -209,6 +209,7 @@ def _autophase(data, coords, dim, deriv, gamma):
             )
         )
     ph0, ph1 = xopt
+    # returns in radians
     return ph0, ph1
 
 


### PR DESCRIPTION
- [ ] passes `black .`

fixed error in conversion of phase values: radians -> deg and phasing is now correct
