### PR TITLE
Change the way to read install require

### DIFF
--- a/.github/workflows/build-test-python-package.yml
+++ b/.github/workflows/build-test-python-package.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: true 
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: ['3.8', '3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-test-python-package.yml
+++ b/.github/workflows/build-test-python-package.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: true 
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: ['3.8', '3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-numpy>=1.24
-scipy>=1.10
-matplotlib>=3.7
-h5py>=3.10
-scikit-rf>=0.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24
 scipy>=1.10
 matplotlib>=3.7
-h5py>=3.8
+h5py>=3.10
 scikit-rf>=0.30.0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,21 @@ with open("dnplab/version.py", "r") as f:
     # Define __version__
     exec(f.read())
 
+with open("requirements.txt", "r") as f:
+    _all_packages_ = []
+    for line in f:
+        _all_packages_.append(line)
+    
+    # remove optional packages
+    _optional_packages_ = ['scikit-rf']
+    for optional_package in _optional_packages_:
+        for i in range(len(_all_packages_)):
+            if optional_package in _all_packages_[i]:
+                _all_packages_.pop(i)
+
+    _install_requires_ = _all_packages_
+    
+
 setup(
     name="dnplab",
     packages=setuptools.find_packages(),
@@ -27,12 +42,7 @@ setup(
     },
     keywords=["ODNP", "DNP", "NMR"],
     python_requires=">=3.8",
-    install_requires=[
-        "numpy>=1.24",
-        "scipy>=1.10",
-        "matplotlib>=3.7",
-        "h5py>=3.10",
-    ],
+    install_requires= _install_requires_,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
- [ ] closes issue #477
- [ ] tests added / passed `pytest .`
- [ ] passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [ ] what's new
The setup.py is reading requirements.txt
