### PR TITLE
fixed forwarded plot behaviour - now compatible with formatted dnplab cfg

### DIFF
--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -91,6 +91,7 @@ def plot(data, *args, **kwargs):
     use_default = True
     plot_function_list = []
     for k in _forwarded_pyplot_plots:
+        k = k.strip()
         if bool(kwargs.pop(k, None)):
             plot_function_list.append(getattr(_plt, k))
             use_default = False


### PR DESCRIPTION
forwarded plot string list in the dnplab.cfg can contain spaces - which does not allow forwarded plots in dnp.plot, this is now fixed