### PR TITLE
removed context manager for dnplab, now the matplotlib_rc params are directly manipulated

### DIFF
--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -26,6 +26,14 @@ _cycler_list = [
 _plt.rcParams["lines.linewidth"] = 1.5
 _plt.rcParams["axes.prop_cycle"] = _plt.cycler(color=_cycler_list)
 
+#As discussed: for now change the rcParams, we do not use a temporary context - the values are stored in the dnplab config
+_plt.rcParams["font.family"] = "Arial"
+_plt.rcParams["pdf.fonttype"] = 42
+_plt.rcParams["font.size"] = 14
+
+# default context
+#_dnpContext = {"font.family": "Arial", "pdf.fonttype": 42, "font.size":14}
+
 show = _plt.show
 
 
@@ -84,7 +92,6 @@ def plot(data, *args, **kwargs):
     data.unfold(dim)
 
     # default context
-    dnpContext = {"font.family": "Arial", "pdf.fonttype": 42}
 
     # will try to plot various pyplot utility plot functions into same axis, the use should know what he does!
     # no unittest added, but only hand tested with semilogy and normal plot works as intended ni fancy_plot)
@@ -96,12 +103,10 @@ def plot(data, *args, **kwargs):
             plot_function_list.append(getattr(_plt, k))
             use_default = False
             plot_return = []
-    with _plt.rc_context(dnpContext):
-        for f in plot_function_list:
-            plot_return.append(f(coord, data.values.real, *args, **kwargs))
+    for f in plot_function_list:
+        plot_return.append(f(coord, data.values.real, *args, **kwargs))
     if use_default:
-        with _plt.rc_context(dnpContext):
-            plot_return = _plt.plot(coord, data.values.real, *args, **kwargs)
+        plot_return = _plt.plot(coord, data.values.real, *args, **kwargs)
     fontsize_xlabel = DNPLAB_CONFIG.getint("PLOTTING", "fontsize_xlabel")
     _plt.xlabel(dim, fontsize=fontsize_xlabel)
     _plt.ylabel("", fontsize=fontsize_xlabel)
@@ -136,9 +141,6 @@ def fancy_plot(data, xlim=[], title="", showPar=False, *args, **kwargs):
 
     """
 
-    # default context
-    dnpContext = {"font.family": "Arial", "pdf.fonttype": 42}
-
     if "experiment_type" not in data.attrs:
         warn("experiment_type not defined in data.attrs, falling back to plot function")
         plot(data, *args, **kwargs)
@@ -169,23 +171,22 @@ def fancy_plot(data, xlim=[], title="", showPar=False, *args, **kwargs):
         coord = data.coords[dim]
         data.unfold(dim)
 
-        with _plt.rc_context(dnpContext):
-            plot_return = _plt.plot(coord, data.values.real, *args, **kwargs)
-            _plt.xlabel("Chemical Shift $\delta$ (ppm)")
-            _plt.ylabel("NMR Signal Intensity (a.u.)")
+        plot_return = _plt.plot(coord, data.values.real, *args, **kwargs)
+        _plt.xlabel("Chemical Shift $\delta$ (ppm)")
+        _plt.ylabel("NMR Signal Intensity (a.u.)")
 
-            _plt.xlim(max(coord), min(coord))
+        _plt.xlim(max(coord), min(coord))
 
-            if xlim != []:
-                _plt.xlim(xlim[1], xlim[0])
+        if xlim != []:
+            _plt.xlim(xlim[1], xlim[0])
 
-            if showPar == True:
-                parameterString = "Freq: " + str(round(data.attrs["nmr_frequency"], 4))
+        if showPar == True:
+            parameterString = "Freq: " + str(round(data.attrs["nmr_frequency"], 4))
 
-                box_style = dict(boxstyle="round", facecolor="white", alpha=0.25)
-                xmin, xmax, ymin, ymax = _plt.axis()
+            box_style = dict(boxstyle="round", facecolor="white", alpha=0.25)
+            xmin, xmax, ymin, ymax = _plt.axis()
 
-                _plt.text(xmin * 0.95, ymax / 10, parameterString, bbox=box_style)
+            _plt.text(xmin * 0.95, ymax / 10, parameterString, bbox=box_style)
 
         data.fold()
 
@@ -212,16 +213,15 @@ def fancy_plot(data, xlim=[], title="", showPar=False, *args, **kwargs):
             kwargs
         )  # calling values take precedence over config values
 
-        with _plt.rc_context(dnpContext):
-            plot_return = _plt.plot(
-                coord,
-                data.values.real * get_float_key("value_scaling"),
-                *args,
-                **plt_config_kwargs
-            )
+        plot_return = _plt.plot(
+            coord,
+            data.values.real * get_float_key("value_scaling"),
+            *args,
+            **plt_config_kwargs
+        )
 
-            if xlim != []:
-                _plt.xlim(xlim[0], xlim[1])
+        if xlim != []:
+            _plt.xlim(xlim[0], xlim[1])
 
         ax = _plt.gca()
         fig = _plt.gcf()
@@ -242,8 +242,7 @@ def fancy_plot(data, xlim=[], title="", showPar=False, *args, **kwargs):
                     )
 
         if title != "":
-            with _plt.rc_context(dnpContext):
-                _plt.title(title)
+            _plt.title(title)
 
         if showPar:
             prmString = ""
@@ -276,8 +275,7 @@ def fancy_plot(data, xlim=[], title="", showPar=False, *args, **kwargs):
             box_style = dict(boxstyle="round", facecolor="white", alpha=0.25)
             xmin, xmax, ymin, ymax = _plt.axis()
 
-            with _plt.rc_context(dnpContext):
-                _plt.text(xmin * 1.001, ymin * 0.90, prmString, bbox=box_style)
+            _plt.text(xmin * 1.001, ymin * 0.90, prmString, bbox=box_style)
 
         data.fold()
 

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -26,13 +26,13 @@ _cycler_list = [
 _plt.rcParams["lines.linewidth"] = 1.5
 _plt.rcParams["axes.prop_cycle"] = _plt.cycler(color=_cycler_list)
 
-#As discussed: for now change the rcParams, we do not use a temporary context - the values are stored in the dnplab config
+# As discussed: for now change the rcParams, we do not use a temporary context - the values are stored in the dnplab config
 _plt.rcParams["font.family"] = "Arial"
 _plt.rcParams["pdf.fonttype"] = 42
 _plt.rcParams["font.size"] = 14
 
 # default context
-#_dnpContext = {"font.family": "Arial", "pdf.fonttype": 42, "font.size":14}
+# _dnpContext = {"font.family": "Arial", "pdf.fonttype": 42, "font.size":14}
 
 show = _plt.show
 

--- a/dnplab/plotting/general.py
+++ b/dnplab/plotting/general.py
@@ -107,9 +107,9 @@ def plot(data, *args, **kwargs):
         plot_return.append(f(coord, data.values.real, *args, **kwargs))
     if use_default:
         plot_return = _plt.plot(coord, data.values.real, *args, **kwargs)
-    fontsize_xlabel = DNPLAB_CONFIG.getint("PLOTTING", "fontsize_xlabel")
-    _plt.xlabel(dim, fontsize=fontsize_xlabel)
-    _plt.ylabel("", fontsize=fontsize_xlabel)
+    # fontsize_xlabel = DNPLAB_CONFIG.getint("PLOTTING", "fontsize_xlabel")
+    _plt.xlabel(dim)  # , fontsize=fontsize_xlabel)
+    # _plt.ylabel("", fontsize=fontsize_xlabel)
     data.fold()
 
     return plot_return


### PR DESCRIPTION
as in the title

added "fonts.size" = 14  to default values

EDIT: correct font size is 14, not 15