### PR TITLE
Remove matplotlib version in requirement file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.0.0
 scipy==1.14.0
-matplotlib
+matplotlib==3.9.0
 h5py==3.11.0
 scikit-rf==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.0.0
 scipy==1.14.0
-matplotlib==3.9.1
+matplotlib
 h5py==3.11.0
 scikit-rf==1.1.0


### PR DESCRIPTION
The matplotlib has an installation problem in 3.9.1. Therefore, the specific version is removed from requirement for now.