### PR TITLE
Debug JEOL Data 

### DIFF
--- a/dnplab/io/load.py
+++ b/dnplab/io/load.py
@@ -263,6 +263,7 @@ def _convert_dnplab_attrs(data, exp_key):
     params_list = params.split("*")
     new_params = 1
     for key in params_list:
+
         params = data.attrs["".join(key.split())]
         if isinstance(params, str):
             if "." in params and (

--- a/dnplab/io/load.py
+++ b/dnplab/io/load.py
@@ -265,12 +265,16 @@ def _convert_dnplab_attrs(data, exp_key):
     for key in params_list:
         params = data.attrs["".join(key.split())]
         if isinstance(params, str):
-            try:
-                new_params *= int(re.findall("\d+", params)[0])
-            except:
+            if "." in params and (
+                params.find(".") == len(params) - 1
+                or params[params.find(".") + 1].isdigit()
+            ):  # when number has decimal
                 new_params *= float(
-                    re.findall("[+-]?\d+\.\d+", params)[0]
+                    re.findall(r"[+-]?\d+\.\d+", params)[0]
                 )  # remove unexpected characters
+
+            else:
+                new_params *= int(re.findall(r"\d+", params)[0])
         else:
             new_params *= params
     return new_params * scaling_factor

--- a/dnplab/processing/fft.py
+++ b/dnplab/processing/fft.py
@@ -73,7 +73,9 @@ def fourier_transform(
         f -= 1.0 / (2 * dt)
 
     if convert_to_ppm:
-        if "nmr_frequency" not in out.attrs and "topspin" not in out.attrs:
+        if ("frequency" not in out.dnplab_attrs.keys()) and (
+            "topspin" not in out.attrs.keys()
+        ):
             print(
                 "NMR frequency not found in the attrs dictionary. Conversion from ppm to Hz requires the NMR frequency."
             )
@@ -89,7 +91,7 @@ def fourier_transform(
                 - sw * (f.size - 1) / f.size
             )
         else:
-            nmr_frequency = out.attrs["nmr_frequency"]
+            nmr_frequency = out.dnplab_attrs["frequency"]
             f /= nmr_frequency / 1.0e6  # updated
 
     out.values = _np.fft.fft(out.values, n=n_pts, axis=index)

--- a/unittests/test_dnp_nmr.py
+++ b/unittests/test_dnp_nmr.py
@@ -16,7 +16,7 @@ class dnpNMR_tester(unittest.TestCase):
         t2 = np.r_[0 : 1 : 1j * pts]
         y = np.exp(1j * t2 * omega) * np.exp(-1 * t2 / tau)
         self.data = dnp.DNPData(y, ["t2"], [t2])
-        self.data.attrs["nmr_frequency"] = 400e6
+        self.data.dnplab_attrs["frequency"] = 400e6
 
     def test_basic_nmr_processing(self):
         data = dnp.remove_background(self.data)

--- a/unittests/test_fft.py
+++ b/unittests/test_fft.py
@@ -16,7 +16,7 @@ class dnpNMR_tester(unittest.TestCase):
         t2 = np.r_[0 : 1 : 1j * pts]
         y = np.exp(1j * t2 * omega) * np.exp(-1 * t2 / tau)
         self.data = dnp.DNPData(y, ["t2"], [t2])
-        self.data.attrs["nmr_frequency"] = 400e6
+        self.data.dnplab_attrs["frequency"] = 400e6
 
     def test_fourier_transform_functions(self):
         self.data = dnp.fourier_transform(self.data, zero_fill_factor=4)


### PR DESCRIPTION
- [ ] closes issue #559
- [ ] tests added / passed `pytest .`
- [ ] passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [ ] what's new
When a list of values is provided for coords, dnplab will use this list instead of generating linear spacing list
