### PR TITLE
Remove np.where in phase function

### DIFF
--- a/dnplab/processing/phase.py
+++ b/dnplab/processing/phase.py
@@ -281,11 +281,17 @@ def phase(data, dim="f2", p0=0.0, p1=0.0, pivot=None):
 
     """
     # get rid of discontuity of mod @0
-    p0_neg = _np.where(p0 < 0)
-    p1_neg = _np.where(p1 < 0)
+    if not isinstance(p0, _np.ndarray):
+        p0 = _np.array([p0])
 
-    p0 = _np.atleast_1d(_np.array(_np.mod(_np.abs(p0), 360)))
-    p1 = _np.atleast_1d(_np.array(_np.mod(_np.abs(p1), 360)))
+    if not isinstance(p1, _np.ndarray):
+        p1 = _np.array([p1])
+
+    p0_neg = [x for x in range(len(p0)) if p0[x] < 0]
+    p1_neg = [x for x in range(len(p1)) if p1[x] < 0]
+
+    p0 = _np.asarray(_np.mod(_np.abs(p0), 360))
+    p1 = _np.asarray(_np.mod(_np.abs(p1), 360))
     p0[p0_neg] = p0[p0_neg] * -1
     p0[p1_neg] = p0[p1_neg] * -1
 


### PR DESCRIPTION
- [ ] tests added / passed `pytest .`
- [ ] passes `black .`
- [ ] passes `git diff upstream/develop -u -- "*.py" | flake8 --diff`
- [ ] what's new
Remove np.where in phase function 